### PR TITLE
More Rails 4 support

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -177,7 +177,11 @@ module ActiveRecordShards
         resolver.spec
       end
 
-      connection_handler.establish_connection(connection_pool_name, specification_cache[name])
+      if ActiveRecord::VERSION::MAJOR >= 4
+        connection_handler.establish_connection(self, specification_cache[name])
+      else
+        connection_handler.establish_connection(connection_pool_name, specification_cache[name])
+      end
     end
 
     def specification_cache


### PR DESCRIPTION
This is similar to how connection_specification.rb was fixed in f455443

Without this change, I could not start a Rails 4 console.

cc/ @osheroff, @lukkry, @grosser
