### PR TITLE
Fix calls to .establish_connection

### DIFF
--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -1,18 +1,18 @@
 require 'active_record'
 require 'active_record/base'
 require 'active_record_shards/configuration_parser'
+require 'active_record_shards/connection_pool'
 require 'active_record_shards/model'
 require 'active_record_shards/shard_selection'
 require 'active_record_shards/connection_switcher'
 require 'active_record_shards/association_collection_connection_selection'
-require 'active_record_shards/connection_pool'
 require 'active_record_shards/migration'
 require 'active_record_shards/default_slave_patches'
 require 'active_record_shards/connection_handler'
 require 'active_record_shards/connection_specification'
 
 if ActiveRecord::VERSION::MAJOR >= 4
-  methods_to_override = [:establish_connection, :remove_connection, :pool_for,
+  methods_to_override = [:remove_connection, :pool_for,
                          :pool_from_any_process_for]
   ActiveRecordShards::ConnectionSpecification = ActiveRecord::ConnectionAdapters::ConnectionSpecification
 else

--- a/lib/active_record_shards/connection_specification.rb
+++ b/lib/active_record_shards/connection_specification.rb
@@ -11,7 +11,8 @@ class ActiveRecord::Base
     specification_cache[connection_pool_name] = spec
 
     if ActiveRecord::VERSION::MAJOR >= 4
-      connection_handler.establish_connection self, spec
+      new_pool_name = ActiveRecordShards::ConnectionPoolNameDecorator.new(connection_pool_name)
+      connection_handler.establish_connection new_pool_name, spec
     else
       connection_handler.establish_connection connection_pool_name, spec
     end

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -178,7 +178,8 @@ module ActiveRecordShards
       end
 
       if ActiveRecord::VERSION::MAJOR >= 4
-        connection_handler.establish_connection(self, specification_cache[name])
+        new_pool_name = ConnectionPoolNameDecorator.new(connection_pool_name)
+        connection_handler.establish_connection(new_pool_name, specification_cache[name])
       else
         connection_handler.establish_connection(connection_pool_name, specification_cache[name])
       end


### PR DESCRIPTION
We override `.establish_connection` in the ActiveRecordHostPool gem, so `.override_connection_handler_methods` had no effect for `.establish_connection`.

With this change, we can actually run the specs for HC.

cc/ @lukkry @grosser @osheroff @staugaard 
