### PR TITLE
Add Base.shards for console-convience

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -1,3 +1,5 @@
+require 'active_record_shards/shard_support'
+
 module ActiveRecordShards
   module ConnectionSwitcher
     def self.extended(klass)
@@ -21,6 +23,10 @@ module ActiveRecordShards
     def on_first_shard(&block)
       shard_name = shard_names.first
       on_shard(shard_name) { yield }
+    end
+
+    def shards
+      ShardSupport.new(self == ActiveRecord::Base ? nil : where(nil))
     end
 
     def on_all_shards(&block)

--- a/lib/active_record_shards/shard_support.rb
+++ b/lib/active_record_shards/shard_support.rb
@@ -1,0 +1,48 @@
+module ActiveRecordShards
+  class ShardSupport
+    class ShardEnumerator
+      include Enumerable
+
+      def each(&block)
+        ActiveRecord::Base.on_all_shards(&block)
+      end
+    end
+
+    def initialize(scope)
+      @scope = scope
+    end
+
+    def enum
+      ShardEnumerator.new
+    end
+
+    def find(*find_args)
+      ensure_concrete!
+
+      exception = nil
+      enum.each do
+        begin
+          record = @scope.find(*find_args)
+          return record if record
+        rescue ActiveRecord::RecordNotFound => e
+          exception = e
+        end
+      end
+      raise exception
+    end
+
+    def count
+      enum.inject(0) { |accum, shard| @scope.clone.count + accum }
+    end
+
+    def to_a
+      enum.flat_map { @scope.clone.to_a }
+    end
+
+    private
+    def ensure_concrete!
+      raise "Please call this method on a concrete model, not an abstract class!" if @scope.abstract_class?
+    end
+  end
+end
+

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -82,6 +82,50 @@ describe "connection switching" do
         assert_equal [["ars_test", nil]], result
       end
     end
+
+    describe ".shards.enum" do
+      it "works like this:" do
+        ActiveRecord::Base.on_all_shards { Ticket.create! }
+        count = ActiveRecord::Base.shards.enum.map { Ticket.count }.inject(&:+)
+        assert_equal(ActiveRecord::Base.shard_names.size, count)
+      end
+    end
+
+    describe ".shards.find" do
+      it "works like this:" do
+        t = ActiveRecord::Base.on_shard(1) { Ticket.create! }
+        assert(Ticket.shards.find(t.id))
+
+        assert_raises(ActiveRecord::RecordNotFound) do
+          Ticket.shards.find(123123123)
+        end
+      end
+    end
+
+    describe ".shards.count" do
+      before do
+        ActiveRecord::Base.on_shard(0) { 2.times { Ticket.create!(:title => "0") } }
+        ActiveRecord::Base.on_shard(1) { Ticket.create!(:title => "1") }
+      end
+
+      it "works like this:" do
+        count = Ticket.shards.count
+        assert_equal(3, count)
+      end
+
+      it "works with scopes" do
+        assert_equal(1, Ticket.where(:title => "1").shards.count)
+      end
+    end
+
+    describe ".shards.to_a" do
+      it "works like this" do
+        ActiveRecord::Base.on_all_shards { |s| Ticket.create!(:title => s.to_s)  }
+
+        res = Ticket.where(:title => "1").shards.to_a
+        assert_equal 1, res.size
+      end
+    end
   end
 
   describe "default shard selection" do


### PR DESCRIPTION
This adds some across-all-shards convience methods for the console:

`Model.shards.find(id)` for finding a record when you're not sure what shard it's on.

`where(nil).shards.to_a` to grab all records across shards 

`where(nil).shards.count` to count across shards

@yadavsaroj @staugaard @zendesk/sustaining 
