### PR TITLE
Fix default spec in establish_connection on rails 4.1

### DIFF
--- a/lib/active_record_shards/connection_specification.rb
+++ b/lib/active_record_shards/connection_specification.rb
@@ -1,7 +1,7 @@
 class ActiveRecord::Base
   def self.establish_connection(spec = ENV["DATABASE_URL"])
     if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 1
-      spec ||= DEFAULT_ENV.call
+      spec ||= ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
       spec = spec.to_sym if spec.is_a?(String)
       resolver = ActiveRecordShards::ConnectionSpecification::Resolver.new configurations
       spec = resolver.spec(spec)


### PR DESCRIPTION
`DEFAULT_ENV` is defined in ActiveRecord::ConnectionHandling on Rails 4.1

/cc @zendesk/octo @zendesk/infrastructure @osheroff 
