### PR TITLE
Fix for v4.2.0 rails abort_if_pending_migrations task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ActiveRecord Shards
 
 ActiveRecord Shards is an extension for ActiveRecord that provides support for sharded database and slaves. Basically it is just a nice way to
-switch between database connection. We've made the implementation very small, and have tried not to reinvent any wheels already present in ActiveRecord.
+switch between database connections. We've made the implementation very small, and have tried not to reinvent any wheels already present in ActiveRecord.
 
-ActiveRecord Shards has used and tested on Rails 2.3.x, 3.0.x, and 3.2.x and has in some form or another been used on in production on a large rails app for
+ActiveRecord Shards has used and tested on Rails 3.0.x, 3.2.x, and 4.1.x and has in some form or another been used in production on a large rails app for
 more than a year.
 
 ## Installation
@@ -38,7 +38,7 @@ Add the slave and shard configuration to config/database.yml:
           slave:
             host: db_shard2_slave
 
-basically connections inherit configuration from the parent the configuration file.
+basically connections inherit configuration from the parent configuration file.
 
 ## Usage
 

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "3.3.0" do |s|
+Gem::Specification.new "active_record_shards", "3.3.1" do |s|
   s.authors     = ["Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["mick@staugaard.com", "eac@zendesk.com", "ben@gimbo.net"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -46,7 +46,11 @@ namespace :db do
   desc "Raises an error if there are pending migrations"
   task :abort_if_pending_migrations => :environment do
     if defined? ActiveRecord
-      pending_migrations = ActiveRecord::Base.on_shard(nil) { ActiveRecord::Migrator.new(:up, 'db/migrate').pending_migrations }
+      if Rails::VERSION::MAJOR >= 4
+        pending_migrations = ActiveRecord::Base.on_shard(nil) { ActiveRecord::Migrator.open(ActiveRecord::Migrator.migrations_paths).pending_migrations }
+      else
+        pending_migrations = ActiveRecord::Base.on_shard(nil) { ActiveRecord::Migrator.new(:up, 'db/migrate').pending_migrations }
+      end
 
       if pending_migrations.any?
         puts "You have #{pending_migrations.size} pending migrations:"


### PR DESCRIPTION
Describe your PR
Fix for the 'abort_if_pending_migrations' task for Rails 4.2.0 while using the zendesk_database_migrations gem. Without the fix, you get the below stack trace. The change matches a change in rails core: https://github.com/rails/rails/commit/fe70cde87cb1c03f1e2fd9e6ffa0877deda589af.

```
➜  zendesk_voyager git:(shender/multi_shard_tests) ✗ be rake -vt db:setup
** Invoke db:setup (first_time)
** Execute db:setup
** Invoke db:create (first_time)
** Invoke db:load_config (first_time)
** Execute db:load_config
** Execute db:create
global_uids_1 already exists
global_uids_2 already exists
** Invoke db:structure:load (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute db:structure:load
voyager_development: Loading structure from /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/zendesk_database_migrations-3/db/structure_main.sql
voyager_development_shard_1: Loading structure from /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/zendesk_database_migrations-3/db/structure_shard.sql
** Invoke db:seed (first_time)
** Execute db:seed
** Invoke db:abort_if_pending_migrations (first_time)
** Invoke environment
** Execute db:abort_if_pending_migrations
rake aborted!
NoMethodError: undefined method `group_by' for "db/migrate":String
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/migration.rb:1013:in `validate'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/migration.rb:920:in `initialize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/tasks.rb:49:in `new'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/tasks.rb:49:in `block (3 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/connection_switcher.rb:18:in `on_shard'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/tasks.rb:49:in `block (2 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `call'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `block in execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/railties/databases.rake:179:in `block (2 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `call'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `block in execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/zendesk_database_migrations-3/lib/zendesk_database_migrations/tasks/shared.rake:141:in `block (2 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `call'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `block in execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:150:in `invoke_task'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block in top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:115:in `run_with_threads'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:100:in `top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:78:in `block in run'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:176:in `standard_exception_handling'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:75:in `run'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/bin/rake:33:in `<top (required)>'
/opt/boxen/rbenv/versions/2.1.5/bin/rake:23:in `load'
/opt/boxen/rbenv/versions/2.1.5/bin/rake:23:in `<main>'
Tasks: TOP => db:abort_if_pending_migrations
```

/cc @gabetax @osheroff @staugaard @grosser 

### References
 - Jira link:

### Risks
 - None