### PR TITLE
check if Rails.env is defined

### DIFF
--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -48,7 +48,7 @@ end
 
 module ActiveRecordShards
   def self.rails_env
-    env = Rails.env if Object.const_defined?(:Rails)
+    env = Rails.env if defined?(Rails.env)
     env ||= RAILS_ENV if Object.const_defined?(:RAILS_ENV)
     env ||= ENV['RAILS_ENV']
   end


### PR DESCRIPTION
I was running into this:

```
NoMethodError: undefined method `env' for Rails:Module
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards.rb:51:in `rails_env'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/shard_selection.rb:41:in `shard_name'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/connection_switcher.rb:113:in `connection_pool_name'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/connection_switcher.rb:203:in `connection_pool_key'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/connection_switcher.rb:213:in `connected_to_shard?'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/connection_switcher.rb:162:in `switch_connection'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/connection_switcher.rb:95:in `on_cx_switch_block'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/connection_switcher.rb:64:in `on_master_or_slave'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/connection_switcher.rb:80:in `on_slave'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/default_slave_patches.rb:80:in `on_slave_unless_tx'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.0/lib/active_record_shards/default_slave_patches.rb:16:in `find_by_sql_with_default_slave'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/relation.rb:638:in `exec_queries'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/relation.rb:514:in `load'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/relation.rb:243:in `to_a'
    /opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/relation/delegation.rb:46:in `map'
```

/cc @zendesk/octo @zendesk/infrastructure 