### PR TITLE
Shender/test purge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ActiveRecord Shards is an extension for ActiveRecord that provides support for sharded database and slaves. Basically it is just a nice way to
 switch between database connections. We've made the implementation very small, and have tried not to reinvent any wheels already present in ActiveRecord.
 
-ActiveRecord Shards has used and tested on Rails 3.0.x, 3.2.x, and 4.1.x and has in some form or another been used in production on a large rails app for
+ActiveRecord Shards has used and tested on Rails 3.0.x, 3.2.x, 4.0.x, and 4.1.x and has in some form or another been used in production on a large rails app for
 more than a year.
 
 ## Installation
@@ -43,7 +43,7 @@ basically connections inherit configuration from the parent configuration file.
 ## Usage
 
 Normally you have some models that live on a shared database, and you might need to query this data in order to know what shard to switch to.
-All the model that live on the shared database must be marked as not\_sharded:
+All the models that live on the shared database must be marked as not\_sharded:
 
     class Account < ActiveRecord::Base
       not_sharded
@@ -55,7 +55,7 @@ All the model that live on the shared database must be marked as not\_sharded:
       belongs_to :account
     end
 
-So in this setup the accounts live on the shared database, but the projects are sharded. If accounts had a shard\_id column, you could lookup the account
+So in this setup the accounts live on the shared database, but the projects are sharded. If accounts have a shard\_id column, you could lookup the account
 in a rack middleware and switch to the right shard:
 
     class AccountMiddleware
@@ -80,7 +80,7 @@ in a rack middleware and switch to the right shard:
       end
     end
 
-Any where in your app, you can switch to the slave databases, by wrapping you code an on\_slave block:
+You can switch to the slave databases at any point by wrapping your code in an on\_slave block:
 
     ActiveRecord::Base.on_slave do
       Account.find_by_big_expensive_query

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -1,6 +1,6 @@
 require 'active_record_shards'
 
-%w[db:drop db:create db:abort_if_pending_migrations db:reset].each do |name|
+%w[db:drop db:create db:abort_if_pending_migrations db:reset db:test:purge].each do |name|
   Rake::Task[name].clear
 end
 

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -12,7 +12,8 @@ namespace :db do
       if key.starts_with?(env_name) && !key.ends_with?("_slave")
         begin
           if ActiveRecord::VERSION::MAJOR >= 4
-            ActiveRecord::Tasks::DatabaseTasks.drop(conf)
+            connection = ActiveRecord::Base.mysql2_connection(conf.merge('database' => nil))
+            connection.drop_database(conf['database'])
           else
             drop_database(conf)
           end
@@ -65,8 +66,12 @@ namespace :db do
   namespace :test do
     desc 'Purges the test databases by dropping and creating'
     task :purge do
+      saved_env = Rails.env
+      Rails.env = 'test'
       Rake::Task['db:drop'].invoke
       Rake::Task['db:create'].invoke
+    ensure
+      Rails.env = saved_env
     end
   end
 end

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -12,7 +12,7 @@ namespace :db do
       if key.starts_with?(env_name) && !key.ends_with?("_slave")
         begin
           if ActiveRecord::VERSION::MAJOR >= 4
-            connection = ActiveRecord::Base.mysql2_connection(conf.merge('database' => nil))
+            connection = ActiveRecord::Base.send("#{conf['adapter']}_connection", conf.merge('database' => nil))
             connection.drop_database(conf['database'])
           else
             drop_database(conf)

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -61,4 +61,12 @@ namespace :db do
       end
     end
   end
+
+  namespace :test do
+    desc 'Purges the test databases by dropping and creating'
+    task :purge do
+      Rake::Task['db:drop'].invoke
+      Rake::Task['db:create'].invoke
+    end
+  end
 end

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -66,12 +66,14 @@ namespace :db do
   namespace :test do
     desc 'Purges the test databases by dropping and creating'
     task :purge do
-      saved_env = Rails.env
-      Rails.env = 'test'
-      Rake::Task['db:drop'].invoke
-      Rake::Task['db:create'].invoke
-    ensure
-      Rails.env = saved_env
+      begin
+        saved_env = Rails.env
+        Rails.env = 'test'
+        Rake::Task['db:drop'].invoke
+        Rake::Task['db:create'].invoke
+      ensure
+        Rails.env = saved_env
+      end
     end
   end
 end


### PR DESCRIPTION
Describe your PR
Add in support for db:test:purge that should basically recreate all the DBs. There was a problem with db:drop where it didn't drop all the DBs. If the main development DB was already dropped, then it couldn't connect to mysql to drop the others.  And it never seemed to be able to drop the global_id_servers.

Also made some minor fixes to the README again.

/cc @gabetax @osheroff @staugaard @grosser @bquorning 

### References
 - Jira link:

### Risks
 - None