### PR TITLE
Shender/rails 4.2 test env db creation fix

### DIFF
--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -51,6 +51,7 @@ module ActiveRecordShards
     env = Rails.env if defined?(Rails.env)
     env ||= RAILS_ENV if Object.const_defined?(:RAILS_ENV)
     env ||= ENV['RAILS_ENV']
+    env ||= 'development'
   end
 end
 

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -86,7 +86,7 @@ end
 module ActiveRecordShards
   module Tasks
     def self.env_name
-      defined?(Rails.env) ? Rails.env : RAILS_ENV || 'development'
+      ActiveRecordShards.rails_env || 'development'
     end
 
     def self.root_connection(conf)

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -8,7 +8,7 @@ namespace :db do
   desc 'Drops the database for the current RAILS_ENV including shards'
   task :drop => :load_config do
     ActiveRecord::Base.configurations.each do |key, conf|
-      if key.starts_with?(ActiveRecordShards::Tasks.env_name) && !key.ends_with?("_slave")
+      if key.starts_with?(ActiveRecordShards.rails_env) && !key.ends_with?("_slave")
         begin
           if ActiveRecord::VERSION::MAJOR >= 4
             ActiveRecordShards::Tasks.root_connection(conf).drop_database(conf['database'])
@@ -30,7 +30,7 @@ namespace :db do
   desc "Create the database defined in config/database.yml for the current RAILS_ENV including shards"
   task :create => :load_config do
     ActiveRecord::Base.configurations.each do |key, conf|
-      if key.starts_with?(ActiveRecordShards::Tasks.env_name) && !key.ends_with?("_slave")
+      if key.starts_with?(ActiveRecordShards.rails_env) && !key.ends_with?("_slave")
         if ActiveRecord::VERSION::MAJOR >= 4
           begin
             ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'])
@@ -46,7 +46,7 @@ namespace :db do
         end
       end
     end
-    ActiveRecord::Base.establish_connection(ActiveRecordShards::Tasks.env_name)
+    ActiveRecord::Base.establish_connection(ActiveRecordShards.rails_env)
   end
 
   desc "Raises an error if there are pending migrations"
@@ -85,10 +85,6 @@ end
 
 module ActiveRecordShards
   module Tasks
-    def self.env_name
-      ActiveRecordShards.rails_env || 'development'
-    end
-
     def self.root_connection(conf)
       ActiveRecord::Base.send("#{conf['adapter']}_connection", conf.merge('database' => nil))
     end


### PR DESCRIPTION
I was having problems with creating DBs in the test environment. Now the 'drop' and 'create' are consistent.

```
➜  zendesk_voyager git:(shender/multi_shard_tests) RAILS_ENV=test be rake db:test:purge --trace
** Invoke db:test:purge (first_time)
** Invoke db:load_config (first_time)
** Execute db:load_config
** Execute db:test:purge
** Invoke db:drop (first_time)
** Invoke db:load_config
** Execute db:drop
** Invoke db:create (first_time)
** Invoke db:load_config
** Execute db:create
Unknown database 'voyager_test_main'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/mysql2_adapter.rb:22:in `rescue in mysql2_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/mysql2_adapter.rb:10:in `mysql2_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/zendesk_database_support-1.11.0/lib/zendesk_database_support/fix_mysql2_symbolized_keys.rb:7:in `mysql2_connection_with_symbolize_keys'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:436:in `new_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:446:in `checkout_new_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:422:in `acquire_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:349:in `block in checkout'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:348:in `checkout'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:263:in `block in connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:262:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_host_pool-0.8.1/lib/active_record_host_pool/pool_proxy.rb:37:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:565:in `retrieve_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_handling.rb:113:in `retrieve_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_handling.rb:87:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/tasks/mysql_database_tasks.rb:8:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/tasks/mysql_database_tasks.rb:16:in `create'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/tasks/database_tasks.rb:93:in `create'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:41:in `block (3 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:35:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:35:in `block (2 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `call'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `block in execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:180:in `block in invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:173:in `invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:84:in `block (3 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `call'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `block in execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:180:in `block in invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:173:in `invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:150:in `invoke_task'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block in top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:115:in `run_with_threads'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:100:in `top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:78:in `block in run'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:176:in `standard_exception_handling'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:75:in `run'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/bin/rake:33:in `<top (required)>'
/opt/boxen/rbenv/versions/2.1.5/bin/rake:23:in `load'
/opt/boxen/rbenv/versions/2.1.5/bin/rake:23:in `<main>'
Couldn't create database for {"adapter"=>"mysql2", "username"=>"root", "host"=>"127.0.0.1", "port"=>3306, "password"=>nil, "database"=>"voyager_test_main", "shard_names"=>[1, 2, 3, 4]}
Unknown database 'voyager_test_main'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/mysql2_adapter.rb:22:in `rescue in mysql2_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/mysql2_adapter.rb:10:in `mysql2_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/zendesk_database_support-1.11.0/lib/zendesk_database_support/fix_mysql2_symbolized_keys.rb:7:in `mysql2_connection_with_symbolize_keys'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:436:in `new_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:446:in `checkout_new_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:422:in `acquire_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:349:in `block in checkout'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:348:in `checkout'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:263:in `block in connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:262:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_host_pool-0.8.1/lib/active_record_host_pool/pool_proxy.rb:37:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:565:in `retrieve_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_handling.rb:113:in `retrieve_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_handling.rb:87:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/tasks/mysql_database_tasks.rb:8:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/tasks/mysql_database_tasks.rb:16:in `create'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/tasks/database_tasks.rb:93:in `create'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:41:in `block (3 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:35:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:35:in `block (2 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `call'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `block in execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:180:in `block in invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:173:in `invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:84:in `block (3 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `call'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `block in execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:180:in `block in invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:173:in `invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:150:in `invoke_task'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block in top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:115:in `run_with_threads'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:100:in `top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:78:in `block in run'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:176:in `standard_exception_handling'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:75:in `run'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/bin/rake:33:in `<top (required)>'
/opt/boxen/rbenv/versions/2.1.5/bin/rake:23:in `load'
/opt/boxen/rbenv/versions/2.1.5/bin/rake:23:in `<main>'
Couldn't create database for {"adapter"=>"mysql2", "username"=>"root", "host"=>"127.0.0.1", "port"=>3306, "password"=>nil, "database"=>"voyager_test_global_uids"}
Unknown database 'voyager_test_main'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/mysql2_adapter.rb:22:in `rescue in mysql2_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/mysql2_adapter.rb:10:in `mysql2_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/zendesk_database_support-1.11.0/lib/zendesk_database_support/fix_mysql2_symbolized_keys.rb:7:in `mysql2_connection_with_symbolize_keys'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:436:in `new_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:446:in `checkout_new_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:422:in `acquire_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:349:in `block in checkout'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:348:in `checkout'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:263:in `block in connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:262:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_host_pool-0.8.1/lib/active_record_host_pool/pool_proxy.rb:37:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/connection_pool.rb:565:in `retrieve_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_handling.rb:113:in `retrieve_connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/connection_handling.rb:87:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/tasks/mysql_database_tasks.rb:8:in `connection'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/tasks/mysql_database_tasks.rb:16:in `create'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/activerecord-4.2.0/lib/active_record/tasks/database_tasks.rb:93:in `create'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:41:in `block (3 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:35:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:35:in `block (2 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `call'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `block in execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:180:in `block in invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:173:in `invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/active_record_shards-3.3.5/lib/active_record_shards/tasks.rb:84:in `block (3 levels) in <top (required)>'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `call'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:241:in `block in execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:236:in `execute'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:180:in `block in invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:173:in `invoke_with_call_chain'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:150:in `invoke_task'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `each'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block in top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:115:in `run_with_threads'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:100:in `top_level'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:78:in `block in run'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:176:in `standard_exception_handling'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:75:in `run'
/opt/boxen/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/bin/rake:33:in `<top (required)>'
/opt/boxen/rbenv/versions/2.1.5/bin/rake:23:in `load'
/opt/boxen/rbenv/versions/2.1.5/bin/rake:23:in `<main>'
Couldn't create database for {"database"=>"voyager_test_s1", "adapter"=>"mysql2", "username"=>"root", "host"=>"127.0.0.1", "port"=>3306, "password"=>nil, "shard_names"=>[1, 2, 3, 4]}
...
...
```

/cc @gabetax @osheroff @staugaard @grosser @bquorning

### References
 - Jira link:

### Risks
 - None