### PR TITLE
Fix chaining rake tasks.

### DIFF
--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -74,8 +74,8 @@ namespace :db do
       begin
         saved_env = Rails.env
         Rails.env = 'test'
-        Rake::Task['db:drop'].invoke
-        Rake::Task['db:create'].invoke
+        Rake::Task['db:drop'].execute
+        Rake::Task['db:create'].execute
       ensure
         Rails.env = saved_env
       end


### PR DESCRIPTION
Didn't catch this in time, but if someone does:
```
$ RAILS_ENV=test bundle exec rake db:create rake db:test:load
```
Because the 'invoke'  method only executes tasks once during the session, db:create will be called at start, and db:test:load which will eventually calls db:drop and db:create, will only drop the DBs and not re-create them because the db:create has already been called.

So changing to use the 'execute' method.

/cc @gabetax @osheroff @staugaard @grosser @bquorning

### References
 - Jira link:

### Risks
 - None