### PR TITLE
put Rails.env into the shard key

### DIFF
--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -34,7 +34,7 @@ module ActiveRecordShards
 
       # Tradeoff: An Array is a slower Hash key, but joining its elements into
       # one string would generate 3 new String objects needing GC later.
-      key = [the_shard, try_slave, @on_slave]
+      key = [ActiveRecordShards.rails_env, the_shard, try_slave, @on_slave]
 
       @shard_names      ||= {}
       @shard_names[key] ||= begin


### PR DESCRIPTION
if we load the development environment and then tickle a shard, and then
switch to the test environment, our shards are still mapped to the
development shards.

@steved555 @vanchi-zendesk 
