### PR TITLE
base_class should ask AR::Base about is_sharded?

### DIFF
--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -11,7 +11,11 @@ module ActiveRecordShards
       if self == ActiveRecord::Base
         supports_sharding?
       elsif self == base_class
-        @sharded != false
+        if @sharded.nil?
+          ActiveRecord::Base.is_sharded?
+        else
+          @sharded != false
+        end
       else
         base_class.is_sharded?
       end


### PR DESCRIPTION
When a base_class doesn't know if it is sharded, it should ask ActiveRecord::Base.

/cc @zendesk/octo @zendesk/infrastructure @osheroff 
