### PR TITLE
Fix execute of 'rake db:test:load' standalone.

### DIFF
--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -70,7 +70,7 @@ namespace :db do
 
   namespace :test do
     desc 'Purges the test databases by dropping and creating'
-    task :purge do
+    task :purge => :load_config do
       begin
         saved_env = Rails.env
         Rails.env = 'test'


### PR DESCRIPTION
Fix for executing rake task db:test:load in a standalone manner.

/cc @staugaard @osheroff @bquorning @grosser @steved555  

### References
 - Jira link:

### Risks
 - None