### PR TITLE
WIP/POC: Only clear tasks that are defined

### DIFF
--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -1,6 +1,8 @@
 require 'active_record_shards'
 
-%w[db:drop db:create db:abort_if_pending_migrations db:reset db:test:purge].each do |name|
+known_tasks = Rake.application.tasks.map(&:name)
+tasks_to_clear = %w[db:drop db:create db:abort_if_pending_migrations db:reset db:test:purge]
+(known_tasks & tasks_to_clear).each do |name|
   Rake::Task[name].clear
 end
 


### PR DESCRIPTION
WIP: This seems to be needed by https://github.com/zendesk/account_service/pull/24 in order to get `rake db:setup` to work.  I'm not sure I 100% understand what's going on here, so I'm not claiming this is the correct solution- feedback would be appreciated.

/cc @steved555 @ciaranarcher @staugaard @zendesk/lego