### PR TITLE
use a "root connection" for rails 3 db dropping

### DIFF
--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -10,11 +10,7 @@ namespace :db do
     ActiveRecord::Base.configurations.each do |key, conf|
       if key.starts_with?(ActiveRecordShards.rails_env) && !key.ends_with?("_slave")
         begin
-          if ActiveRecord::VERSION::MAJOR >= 4
-            ActiveRecordShards::Tasks.root_connection(conf).drop_database(conf['database'])
-          else
-            drop_database(conf)
-          end
+          ActiveRecordShards::Tasks.root_connection(conf).drop_database(conf['database'])
         rescue Exception => e
           puts "Couldn't drop #{conf['database']} : #{e.inspect}"
         end


### PR DESCRIPTION
@osheroff @grosser 

No idea how this worked before, but `ActiveRecordHostPool::PoolProxy` is caching the dropped database until it hits a `Mysql2::Error` so `db:drop` only works for every other database in the configuration.

Tested this locally, seems to work fine.