### PR TITLE
Fix charset / collation for rails 4

### DIFF
--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -29,6 +29,8 @@ namespace :db do
       if key.starts_with?(ActiveRecordShards.rails_env) && !key.ends_with?("_slave")
         if ActiveRecord::VERSION::MAJOR >= 4
           begin
+            # MysqlAdapter takes charset instead of encoding in Rails 4
+            # https://github.com/rails/rails/commit/78b30fed9336336694fb2cb5d2825f95800b541c
             symbolized_configuration = conf.symbolize_keys
             symbolized_configuration[:charset] = symbolized_configuration[:encoding]
 

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -29,7 +29,7 @@ namespace :db do
       if key.starts_with?(ActiveRecordShards.rails_env) && !key.ends_with?("_slave")
         if ActiveRecord::VERSION::MAJOR >= 4
           begin
-            ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'], conf)
+            ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'], conf.symbolize_keys)
           rescue ActiveRecord::StatementInvalid => ex
             if ex.message.include?('database exists')
               puts "#{conf['database']} already exists"

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -29,7 +29,10 @@ namespace :db do
       if key.starts_with?(ActiveRecordShards.rails_env) && !key.ends_with?("_slave")
         if ActiveRecord::VERSION::MAJOR >= 4
           begin
-            ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'], conf.symbolize_keys)
+            symbolized_configuration = conf.symbolize_keys
+            symbolized_configuration[:charset] = symbolized_configuration[:encoding]
+
+            ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'], symbolized_configuration)
           rescue ActiveRecord::StatementInvalid => ex
             if ex.message.include?('database exists')
               puts "#{conf['database']} already exists"

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -29,7 +29,7 @@ namespace :db do
       if key.starts_with?(ActiveRecordShards.rails_env) && !key.ends_with?("_slave")
         if ActiveRecord::VERSION::MAJOR >= 4
           begin
-            ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'])
+            ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'], conf)
           rescue ActiveRecord::StatementInvalid => ex
             if ex.message.include?('database exists')
               puts "#{conf['database']} already exists"


### PR DESCRIPTION
Fixes charset / collation for database creation. Sort of a corollary to https://github.com/rails/rails/commit/78b30fed9336336694fb2cb5d2825f95800b541c. This all works fine in Rails 3.

@osheroff @danapczynski 

cc @zendesk/octo 