### PR TITLE
Instantiate fewer objects

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -2,6 +2,8 @@ require 'active_record_shards/shard_support'
 
 module ActiveRecordShards
   module ConnectionSwitcher
+    SHARD_NAMES_CONFIG_KEY = 'shard_names'.freeze
+
     def self.extended(klass)
       klass.singleton_class.alias_method_chain :columns, :default_shard
       klass.singleton_class.alias_method_chain :table_exists?, :default_shard
@@ -144,7 +146,7 @@ module ActiveRecordShards
       unless config = configurations[shard_env]
         raise "Did not find #{shard_env} in configurations, did you forget to add it to your database.yml ? (configurations: #{configurations.inspect})"
       end
-      config['shard_names'] || []
+      config[SHARD_NAMES_CONFIG_KEY] || []
     end
 
     private

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -32,12 +32,10 @@ module ActiveRecordShards
     def shard_name(klass = nil, try_slave = true)
       the_shard = shard(klass)
 
-      # Tradeoff: An Array is a slower Hash key, but joining its elements into
-      # one string would generate 3 new String objects needing GC later.
-      key = [ActiveRecordShards.rails_env, the_shard, try_slave, @on_slave]
-
-      @shard_names      ||= {}
-      @shard_names[key] ||= begin
+      @shard_names ||= {}
+      @shard_names[the_shard] ||= {}
+      @shard_names[the_shard][try_slave] ||= {}
+      @shard_names[the_shard][try_slave][@on_slave] ||= begin
         s = ActiveRecordShards.rails_env.dup
         s << "_shard_#{the_shard}" if the_shard
         s << "_slave"              if @on_slave && try_slave

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -12,7 +12,7 @@ module ActiveRecordShards
         if @shard == NO_SHARD
           nil
         else
-          (@shard || self.class.default_shard).to_s
+          @shard || self.class.default_shard
         end
       end
     end


### PR DESCRIPTION
I was toying a bit with profiling again, and noticed that we are producing an awful lot of String objects in this gem. Which is bad, since it’s used a lot, for all requests.

By freezing the `'shard_names'` string, and not converting the shard ID integer into a string, we can save several hundred object allocations per request on a busy page.

cc @grosser @osheroff @staugaard 
