### PR TITLE
No alias_method_chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,3 @@ cache:
   bundler: true
 branches:
   only: master
-matrix:
-  exclude:
-    - rvm: 2.2.2
-      gemfile: gemfiles/rails3.2.gemfile
-    - rvm: rbx-2
-      gemfile: gemfiles/rails3.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.5
+  - 2.1.6
+  - 2.2.2
   - rbx-2
 gemfile:
   - gemfiles/rails3.2.gemfile
@@ -15,3 +15,9 @@ cache:
   bundler: true
 branches:
   only: master
+matrix:
+  exclude:
+    - rvm: 2.2.2
+      gemfile: gemfiles/rails3.2.gemfile
+    - rvm: rbx-2
+      gemfile: gemfiles/rails3.2.gemfile

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -6,6 +6,8 @@ Gem::Specification.new "active_record_shards", "3.5.0-alpha" do |s|
   s.description = "Easily run queries on shard and slave databases."
   s.license     = "MIT"
 
+  s.required_ruby_version = "~> 2.0"
+
   s.add_runtime_dependency("activerecord", ">= 3.2.16", "< 5.0")
   s.add_runtime_dependency("activesupport", ">= 3.2.16", "< 5.0")
 

--- a/lib/active_record_shards/configuration_parser.rb
+++ b/lib/active_record_shards/configuration_parser.rb
@@ -35,16 +35,15 @@ module ActiveRecordShards
       end
     end
 
-    def configurations_with_shard_explosion=(conf)
-      self.configurations_without_shard_explosion = explode(conf)
+    module PrependMethods
+      def configurations=(conf)
+        super(explode(conf))
+      end
     end
 
     def ConfigurationParser.extended(klass)
-      klass.singleton_class.alias_method_chain :configurations=, :shard_explosion
-
-      if !klass.configurations.nil? && !klass.configurations.empty?
-        klass.configurations = klass.configurations
-      end
+      klass.singleton_class.send(:prepend, PrependMethods)
+      klass.configurations = klass.configurations if klass.configurations.present?
     end
   end
 end

--- a/lib/active_record_shards/connection_pool.rb
+++ b/lib/active_record_shards/connection_pool.rb
@@ -13,21 +13,20 @@ module ActiveRecordShards
   #   ActiveRecordShards.override_connection_handler_methods(methods_to_override)
   #
   def self.override_connection_handler_methods(method_names)
+    injected_module = Module.new
     method_names.each do |method_name|
-      ActiveRecord::ConnectionAdapters::ConnectionHandler.class_eval do
-        define_method("#{method_name}_with_connection_pool_name") do |*args|
-          unless args[0].is_a? ConnectionPoolNameDecorator
-            name = if args[0].is_a? String
-                     args[0]
-                   else
-                     args[0].connection_pool_name
-                   end
-            args[0] = ConnectionPoolNameDecorator.new(name)
-          end
-          send("#{method_name}_without_connection_pool_name", *args)
+      injected_module.send(:define_method, method_name) do |*args|
+        unless args[0].is_a? ConnectionPoolNameDecorator
+          name = if args[0].is_a? String
+                   args[0]
+                 else
+                   args[0].connection_pool_name
+                 end
+          args[0] = ConnectionPoolNameDecorator.new(name)
         end
-        alias_method_chain method_name, :connection_pool_name
+        super(*args)
       end
     end
+    ActiveRecord::ConnectionAdapters::ConnectionHandler.send(:prepend, injected_module)
   end
 end

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -4,9 +4,28 @@ module ActiveRecordShards
   module ConnectionSwitcher
     SHARD_NAMES_CONFIG_KEY = 'shard_names'.freeze
 
+    module PrependMethods
+      def columns
+        if is_sharded? && current_shard_id.nil? && table_name != ActiveRecord::Migrator.schema_migrations_table_name
+          on_first_shard { super }
+        else
+          super
+        end
+      end
+
+      def table_exists?
+        result = super()
+
+        if !result && is_sharded? && (shard_name = shard_names.first)
+          result = on_shard(shard_name) { super }
+        end
+
+        result
+      end
+    end
+
     def self.extended(klass)
-      klass.singleton_class.alias_method_chain :columns, :default_shard
-      klass.singleton_class.alias_method_chain :table_exists?, :default_shard
+      klass.singleton_class.send(:prepend, ActiveRecordShards::ConnectionSwitcher::PrependMethods)
     end
 
     def default_shard=(new_default_shard)
@@ -213,24 +232,6 @@ module ActiveRecordShards
       end
 
       specs_to_pools.has_key?(connection_pool_key)
-    end
-
-    def columns_with_default_shard
-      if is_sharded? && current_shard_id.nil? && table_name != ActiveRecord::Migrator.schema_migrations_table_name
-        on_first_shard { columns_without_default_shard }
-      else
-        columns_without_default_shard
-      end
-    end
-
-    def table_exists_with_default_shard?
-      result = table_exists_without_default_shard?
-
-      if !result && is_sharded? && (shard_name = shard_names.first)
-        result = on_shard(shard_name) { table_exists_without_default_shard? }
-      end
-
-      result
     end
 
     def autoload_adapter(adapter_name)

--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -9,66 +9,59 @@ module ActiveRecordShards
       end
 
       return unless base_methods.include?(method)
-      _, method, punctuation = method.to_s.match(/^(.*?)([\?\!]?)$/).to_a
-      base.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        #{class_method ? "class << self" : ""}
-          def #{method}_with_default_slave#{punctuation}(*args, &block)
-            on_slave_unless_tx do
-              #{method}_without_default_slave#{punctuation}(*args, &block)
-            end
-          end
-
-          alias_method_chain :#{method}#{punctuation}, :default_slave
-        #{class_method ? "end" : ""}
-      RUBY
+      injected_module = Module.new
+      injected_module.send(:define_method, method) do |*args, &block|
+        on_slave_unless_tx do
+          super(*args, &block)
+        end
+      end
+      (class_method ? base.singleton_class : base).send(:prepend, injected_module)
     end
 
     CLASS_SLAVE_METHODS = [ :find_by_sql, :count_by_sql,  :calculate, :find_one, :find_some, :find_every, :quote_value, :sanitize_sql_hash_for_conditions, :exists?, :table_exists? ]
 
-    def self.extended(base)
-      CLASS_SLAVE_METHODS.each { |m| ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(true, base, m) }
-
-      base.class_eval do
-        # fix ActiveRecord to do the right thing, and use our aliased quote_value
-        def quote_value(*args, &block)
-          self.class.quote_value(*args, &block)
+    module PrependClassMethods
+      def columns
+        if on_slave_by_default? && !Thread.current[:_active_record_shards_slave_off]
+          read_columns_from = :slave
+        else
+          read_columns_form = :master
         end
 
-        def reload_with_slave_off(*args, &block)
-          self.class.on_master { reload_without_slave_off(*args, &block) }
-        end
-        alias_method_chain :reload, :slave_off
+        on_cx_switch_block(read_columns_from, construct_ro_scope: false) { super }
+      end
 
-        class << self
-          def columns_with_default_slave(*args, &block)
-            if on_slave_by_default? && !Thread.current[:_active_record_shards_slave_off]
-              read_columns_from = :slave
-            else
-              read_columns_form = :master
-            end
-
-            on_cx_switch_block(read_columns_from, :construct_ro_scope => false) { columns_without_default_slave(*args, &block) }
-          end
-          alias_method_chain :columns, :default_slave
+      def transaction(*args, &block)
+        if on_slave_by_default?
+          old_val = Thread.current[:_active_record_shards_slave_off]
+          Thread.current[:_active_record_shards_slave_off] = true
         end
 
-        class << self
-          def transaction_with_slave_off(*args, &block)
-            if on_slave_by_default?
-              old_val = Thread.current[:_active_record_shards_slave_off]
-              Thread.current[:_active_record_shards_slave_off] = true
-            end
-
-            transaction_without_slave_off(*args, &block)
-          ensure
-            if on_slave_by_default?
-              Thread.current[:_active_record_shards_slave_off] = old_val
-            end
-          end
-
-          alias_method_chain :transaction, :slave_off
+        super(*args, &block)
+      ensure
+        if on_slave_by_default?
+          Thread.current[:_active_record_shards_slave_off] = old_val
         end
       end
+    end
+
+    module PrependMethods
+      # fix ActiveRecord to do the right thing, and use our aliased quote_value
+      def quote_value(*args, &block)
+        self.class.quote_value(*args, &block)
+      end
+
+      def reload(*args, &block)
+        self.class.on_master { super(*args, &block) }
+      end
+    end
+
+    def self.extended(base)
+      base.send(:prepend, PrependMethods)
+      base.singleton_class.send(:prepend, PrependClassMethods)
+
+      CLASS_SLAVE_METHODS.each { |m| ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(true, base, m) }
+
       if ActiveRecord::Associations.const_defined?(:HasAndBelongsToManyAssociation)
         ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, ActiveRecord::Associations::HasAndBelongsToManyAssociation, :construct_sql)
         ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, ActiveRecord::Associations::HasAndBelongsToManyAssociation, :construct_find_options!)
@@ -96,7 +89,7 @@ module ActiveRecordShards
     end
 
     module HasAndBelongsToManyPreloaderPatches
-      def self.included(base)
+      def self.prepended(base)
         ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :records_for) rescue nil
       end
 
@@ -104,8 +97,8 @@ module ActiveRecordShards
         klass.on_slave_unless_tx { yield }
       end
 
-      def exists_with_default_slave?(*args, &block)
-        on_slave_unless_tx { exists_without_default_slave?(*args, &block) }
+      def exists?(*args, &block)
+        on_slave_unless_tx { super(*args, &block) }
       end
     end
 
@@ -113,14 +106,8 @@ module ActiveRecordShards
     # this simplifies the hell out of our existence, because all we have to do is inerit on-slave-by-default
     # down from the parent now.
     module Rails41HasAndBelongsToManyBuilderExtension
-      def self.included(base)
-        base.class_eval do
-          alias_method_chain :through_model, :inherit_default_slave_from_lhs
-        end
-      end
-
-      def through_model_with_inherit_default_slave_from_lhs
-        model = through_model_without_inherit_default_slave_from_lhs
+      def through_model
+        model = super
         def model.on_slave_by_default?
           left_reflection.klass.on_slave_by_default?
         end

--- a/test/schema_dumper_extension_test.rb
+++ b/test/schema_dumper_extension_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../helper', __FILE__)
 
-if ActiveRecord::VERSION::MAJOR >= 4 && RUBY_VERSION >= '2'
+if ActiveRecord::VERSION::MAJOR >= 4
   describe ActiveRecordShards::SchemaDumperExtension do
     describe "schema dump" do
 


### PR DESCRIPTION
In order to make this gem compatible with Rails 5.0, we need to remove our use of alias_method_chain. Since the alternative (`Module.prepend`) is a Ruby 2-only feature, we must say goodbye to Ruby 1.9 support.

Please note that this commit is almost verbatim copy-pasted from @pschambacher’s PR #50.

@zendesk/zendesk-rails-upgraders 