### PR TITLE
Remove `class_eval` and `class<<self` in extended

### DIFF
--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -24,6 +24,29 @@ module ActiveRecordShards
       RUBY
     end
 
+    def columns_with_default_slave(*args, &block)
+      read_columns_from = if on_slave_by_default? && !Thread.current[:_active_record_shards_slave_off]
+        :slave
+      else
+        :master
+      end
+
+      on_cx_switch_block(read_columns_from, :construct_ro_scope => false) { columns_without_default_slave(*args, &block) }
+    end
+
+    def transaction_with_slave_off(*args, &block)
+      if on_slave_by_default?
+        old_val = Thread.current[:_active_record_shards_slave_off]
+        Thread.current[:_active_record_shards_slave_off] = true
+      end
+
+      transaction_without_slave_off(*args, &block)
+    ensure
+      if on_slave_by_default?
+        Thread.current[:_active_record_shards_slave_off] = old_val
+      end
+    end
+
     CLASS_SLAVE_METHODS = [ :find_by_sql, :count_by_sql,  :calculate, :find_one, :find_some, :find_every, :exists?, :table_exists? ]
 
     def self.extended(base)
@@ -42,32 +65,8 @@ module ActiveRecordShards
         alias_method :reload, :reload_with_slave_off
 
         class << self
-          def columns_with_default_slave(*args, &block)
-            read_columns_from = if on_slave_by_default? && !Thread.current[:_active_record_shards_slave_off]
-              :slave
-            else
-              :master
-            end
-
-            on_cx_switch_block(read_columns_from, :construct_ro_scope => false) { columns_without_default_slave(*args, &block) }
-          end
           alias_method :columns_without_default_slave, :columns
           alias_method :columns, :columns_with_default_slave
-        end
-
-        class << self
-          def transaction_with_slave_off(*args, &block)
-            if on_slave_by_default?
-              old_val = Thread.current[:_active_record_shards_slave_off]
-              Thread.current[:_active_record_shards_slave_off] = true
-            end
-
-            transaction_without_slave_off(*args, &block)
-          ensure
-            if on_slave_by_default?
-              Thread.current[:_active_record_shards_slave_off] = old_val
-            end
-          end
 
           alias_method :transaction_without_slave_off, :transaction
           alias_method :transaction, :transaction_with_slave_off


### PR DESCRIPTION
Define class method directly on the (extend-able) module, and instance method inside an `InstanceMethods` module.

@osheroff @grosser @pschambacher 