### PR TITLE
add rails_env back to the shard selection key

### DIFF
--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -32,13 +32,11 @@ module ActiveRecordShards
     def shard_name(klass = nil, try_slave = true)
       the_shard = shard(klass)
 
-      keys = [ActiveRecordShards.rails_env, the_shard, try_slave]
-
-      hash = keys.inject(@shard_names ||= {}) do |accum, key|
-        accum[key] ||= {}
-      end
-
-      hash[@on_slave] ||= begin
+      @shard_names ||= {}
+      @shard_names[ActiveRecordShards.rails_env] ||= {}
+      @shard_names[ActiveRecordShards.rails_env][the_shard] ||= {}
+      @shard_names[ActiveRecordShards.rails_env][the_shard][try_slave] ||= {}
+      @shard_names[ActiveRecordShards.rails_env][the_shard][try_slave][@on_slave] ||= begin
         s = ActiveRecordShards.rails_env.dup
         s << "_shard_#{the_shard}" if the_shard
         s << "_slave"              if @on_slave && try_slave

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -32,10 +32,13 @@ module ActiveRecordShards
     def shard_name(klass = nil, try_slave = true)
       the_shard = shard(klass)
 
-      @shard_names ||= {}
-      @shard_names[the_shard] ||= {}
-      @shard_names[the_shard][try_slave] ||= {}
-      @shard_names[the_shard][try_slave][@on_slave] ||= begin
+      keys = [ActiveRecordShards.rails_env, the_shard, try_slave]
+
+      hash = keys.inject(@shard_names ||= {}) do |accum, key|
+        accum[key] ||= {}
+      end
+
+      hash[@on_slave] ||= begin
         s = ActiveRecordShards.rails_env.dup
         s << "_shard_#{the_shard}" if the_shard
         s << "_slave"              if @on_slave && try_slave


### PR DESCRIPTION
#51 removed rails_env from the shard selection key which breaks `rake db:test:prepare` without a RAILS_ENV specifically set.

(https://github.com/zendesk/zendesk_database_migrations/blob/master/lib/zendesk_database_migrations/tasks/shared.rake#L152)

@osheroff @bquorning @grosser 