### PR TITLE
POD-602 queries that use joins or includes+references should talk to the slav…

### DIFF
--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -89,9 +89,9 @@ module ActiveRecordShards
 
     module ActiveRelationPatches
       def self.included(base)
-        ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :calculate)
-        ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :exists?)
-        ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :pluck)
+        [:calculate, :exists?, :pluck, :find_with_associations].each do |m|
+          ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, m)
+        end
       end
 
       def on_slave_unless_tx

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -535,6 +535,17 @@ describe "connection switching" do
           assert_equal ["slave_name", "slave_name2"], Account.pluck(:name)
         end
 
+        it "supports implicit joins" do
+          accounts = Account.includes(:tickets)
+          accounts = accounts.references(:tickets) if ActiveRecord::VERSION::MAJOR >= 4
+          assert_equal ["slave_name", "slave_name2"], accounts.order('tickets.id').map(&:name).sort
+        end
+
+        it "supports joins" do
+          accounts = Account.joins('LEFT OUTER JOIN tickets ON tickets.account_id = accounts.id').map(&:name).sort
+          assert_equal ["slave_name", "slave_name2"], accounts
+        end
+
         after do
           Account.on_slave_by_default = false
           Person.on_slave_by_default = false


### PR DESCRIPTION
…e by default

https://zendesk.atlassian.net/browse/POD-602

that should make our worst queries a lot faster / have less impact ...

@osheroff @gabetax 
/cc @jonmoter @bhouse 