### PR TITLE
do not wrap methods that do not go to the master

### DIFF
--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -24,7 +24,7 @@ module ActiveRecordShards
       RUBY
     end
 
-    CLASS_SLAVE_METHODS = [ :find_by_sql, :count_by_sql,  :calculate, :find_one, :find_some, :find_every, :quote_value, :sanitize_sql_hash_for_conditions, :exists?, :table_exists? ]
+    CLASS_SLAVE_METHODS = [ :find_by_sql, :count_by_sql,  :calculate, :find_one, :find_some, :find_every, :exists?, :table_exists? ]
 
     def self.extended(base)
       CLASS_SLAVE_METHODS.each { |m| ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(true, base, m) }


### PR DESCRIPTION
they use connection.xyz ... but nothing that ever hits the database ... so that should be safe ?
-> unnecessary overhead ...

@gabetax @osheroff 