### PR TITLE
Rails 5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ActiveRecord Shards is an extension for ActiveRecord that provides support for sharded database and slaves. Basically it is just a nice way to
 switch between database connections. We've made the implementation very small, and have tried not to reinvent any wheels already present in ActiveRecord.
 
-ActiveRecord Shards has used and tested on Rails 3.2.x, 4.0.x, 4.1.x and 4.2.x and has in some form or another been used in production on a large rails app for
-more than a year.
+ActiveRecord Shards has been used and tested on Rails 3.2, 4.0, 4.1, 4.2 and 5.0 and has in some form or another been used in production on a large Rails app for several years.
 
 ## Installation
 

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,3 +1,3 @@
 eval_gemfile 'gemfiles/common.rb'
 
-gem 'activerecord', '5.0.0.beta3'
+gem 'activerecord', '~> 5.0.0'

--- a/lib/active_record_shards-3-2.rb
+++ b/lib/active_record_shards-3-2.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+require 'active_record_shards/connection_pool'
+require 'active_record_shards/connection_handler'
+require 'active_record_shards/connection_specification'
 
 
 ActiveRecordShards::ConnectionSpecification = ActiveRecord::Base::ConnectionSpecification

--- a/lib/active_record_shards-4-0.rb
+++ b/lib/active_record_shards-4-0.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+require 'active_record_shards/connection_pool'
+require 'active_record_shards/connection_handler'
+require 'active_record_shards/connection_specification'
 require 'active_record_shards/schema_dumper_extension'
 
 ActiveRecordShards::ConnectionSpecification = ActiveRecord::ConnectionAdapters::ConnectionSpecification

--- a/lib/active_record_shards-4-1.rb
+++ b/lib/active_record_shards-4-1.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+require 'active_record_shards/connection_pool'
+require 'active_record_shards/connection_handler'
+require 'active_record_shards/connection_specification'
 require 'active_record_shards/schema_dumper_extension'
 
 ActiveRecordShards::ConnectionSpecification = ActiveRecord::ConnectionAdapters::ConnectionSpecification

--- a/lib/active_record_shards-5-0.rb
+++ b/lib/active_record_shards-5-0.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+
+
+require 'active_record_shards/schema_dumper_extension'
+
+
+
+
+
+ActiveRecord::Associations::Builder::HasAndBelongsToMany.include(ActiveRecordShards::DefaultSlavePatches::Rails41HasAndBelongsToManyBuilderExtension)
+
+ActiveRecord::SchemaDumper.prepend(ActiveRecordShards::SchemaDumperExtension)

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -25,19 +25,6 @@ ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
 ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
 ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)
 
-ActiveRecord::Base.singleton_class.class_eval do
-  def establish_connection_with_connection_pool_name(spec = nil)
-    case spec
-    when ActiveRecordShards::ConnectionSpecification
-      connection_handler.establish_connection(connection_pool_name, spec)
-    else
-      establish_connection_without_connection_pool_name(spec)
-    end
-  end
-  alias_method :establish_connection_without_connection_pool_name, :establish_connection
-  alias_method :establish_connection, :establish_connection_with_connection_pool_name
-end
-
 case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
 when '3.2'
   require 'active_record_shards-3-2'

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -47,4 +47,6 @@ when '4.1', '4.2'
   require 'active_record_shards-4-1'
 when '5.0'
   require 'active_record_shards-5-0'
+else
+  raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"
 end

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -6,11 +6,8 @@ require 'active_record_shards/model'
 require 'active_record_shards/shard_selection'
 require 'active_record_shards/connection_switcher'
 require 'active_record_shards/association_collection_connection_selection'
-require 'active_record_shards/connection_pool'
 require 'active_record_shards/migration'
 require 'active_record_shards/default_slave_patches'
-require 'active_record_shards/connection_handler'
-require 'active_record_shards/connection_specification'
 
 module ActiveRecordShards
   def self.rails_env
@@ -46,6 +43,8 @@ when '3.2'
   require 'active_record_shards-3-2'
 when '4.0'
   require 'active_record_shards-4-0'
-when '4.1', '4.2', '5.0'
+when '4.1', '4.2'
   require 'active_record_shards-4-1'
+when '5.0'
+  require 'active_record_shards-5-0'
 end

--- a/lib/active_record_shards/connection_switcher-4-0.rb
+++ b/lib/active_record_shards/connection_switcher-4-0.rb
@@ -1,0 +1,67 @@
+module ActiveRecordShards
+  module ConnectionSwitcher
+
+    # Name of the connection pool. Used by ConnectionHandler to retrieve the current connection pool.
+    def connection_pool_name # :nodoc:
+      name = current_shard_selection.shard_name(self)
+
+      if configurations[name].nil? && on_slave?
+        current_shard_selection.shard_name(self, false)
+      else
+        name
+      end
+    end
+
+    private
+
+    def ensure_shard_connection
+      establish_shard_connection unless connected_to_shard?
+    end
+
+    def establish_shard_connection
+      name = connection_pool_name
+      spec = configurations[name]
+
+      raise ActiveRecord::AdapterNotSpecified.new("No database defined by #{name} in database.yml") if spec.nil?
+
+      # in 3.2 rails is asking for a connection pool in a map of these ConnectionSpecifications.  If we want to re-use connections,
+      # we need to re-use specs.
+
+      # note that since we're subverting the standard establish_connection path, we have to handle the funky autoloading of the
+      # connection adapter ourselves.
+      specification_cache[name] ||= begin
+        if ActiveRecord::VERSION::STRING >= '4.1.0'
+          resolver = ActiveRecordShards::ConnectionSpecification::Resolver.new configurations
+          resolver.spec(spec)
+        else
+          resolver = ActiveRecordShards::ConnectionSpecification::Resolver.new spec, configurations
+          resolver.spec
+        end
+      end
+
+      if ActiveRecord::VERSION::MAJOR >= 4
+        connection_handler.establish_connection(self, specification_cache[name])
+      else
+        connection_handler.establish_connection(connection_pool_name, specification_cache[name])
+      end
+    end
+
+    def specification_cache
+      @@specification_cache ||= {}
+    end
+
+    def connection_pool_key
+      specification_cache[connection_pool_name]
+    end
+
+    def connected_to_shard?
+      if ActiveRecord::VERSION::MAJOR >= 4
+        specs_to_pools = Hash[connection_handler.connection_pool_list.map { |pool| [pool.spec, pool] }]
+      else
+        specs_to_pools = connection_handler.connection_pools
+      end
+
+      specs_to_pools.has_key?(connection_pool_key)
+    end
+  end
+end

--- a/lib/active_record_shards/connection_switcher-5-0.rb
+++ b/lib/active_record_shards/connection_switcher-5-0.rb
@@ -1,0 +1,26 @@
+module ActiveRecordShards
+  module ConnectionSwitcher
+    def connection_specification_name
+      name = current_shard_selection.resolve_connection_name(sharded: is_sharded?, configurations: self.configurations)
+
+      raise "No configuration found for #{name}" unless configurations[name] || name == "primary"
+      name
+    end
+
+    private
+
+    def ensure_shard_connection
+      # See if we've connected before. If not, call `#establish_connection`
+      # so that ActiveRecord can resolve connection_specification_name to an
+      # ARS connection.
+      spec_name = connection_specification_name
+
+      pool = connection_handler.retrieve_connection_pool(spec_name)
+      if pool.nil?
+        resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new configurations
+        spec = resolver.spec(spec_name.to_sym, spec_name)
+        connection_handler.establish_connection spec
+      end
+    end
+  end
+end

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -8,14 +8,65 @@ module ActiveRecordShards
       @on_slave = false
     end
 
-    def shard(klass = nil)
-      if (@shard || self.class.default_shard) && (klass.nil? || klass.is_sharded?)
-        if @shard == NO_SHARD
+    if ActiveRecord::VERSION::MAJOR < 5
+
+      def shard(klass = nil)
+        if (@shard || self.class.default_shard) && (klass.nil? || klass.is_sharded?)
+          if @shard == NO_SHARD
+            nil
+          else
+            @shard || self.class.default_shard
+          end
+        end
+      end
+
+      def shard_name(klass = nil, try_slave = true)
+        the_shard = shard(klass)
+
+        @shard_names ||= {}
+        @shard_names[ActiveRecordShards.rails_env] ||= {}
+        @shard_names[ActiveRecordShards.rails_env][the_shard] ||= {}
+        @shard_names[ActiveRecordShards.rails_env][the_shard][try_slave] ||= {}
+        @shard_names[ActiveRecordShards.rails_env][the_shard][try_slave][@on_slave] ||= begin
+          s = ActiveRecordShards.rails_env.dup
+          s << "_shard_#{the_shard}" if the_shard
+          s << "_slave"              if @on_slave && try_slave
+          s
+        end
+      end
+
+    else
+
+      def shard
+        if @shard.nil? || @shard == NO_SHARD
           nil
         else
           @shard || self.class.default_shard
         end
       end
+
+      PRIMARY = "primary".freeze
+      def resolve_connection_name(sharded:, configurations:)
+        resolved_shard = sharded ? shard : nil
+
+        if !resolved_shard && !@on_slave
+          return PRIMARY
+        end
+
+        @shard_names ||= {}
+        @shard_names[ActiveRecordShards.rails_env] ||= {}
+        @shard_names[ActiveRecordShards.rails_env][resolved_shard] ||= {}
+        @shard_names[ActiveRecordShards.rails_env][resolved_shard][@on_slave] ||= begin
+          s = ActiveRecordShards.rails_env.dup
+          s << "_shard_#{resolved_shard}" if resolved_shard
+
+          if @on_slave && configurations["#{s}_slave"] # fall back to master connection
+            s << "_slave"
+          end
+          s
+        end
+      end
+
     end
 
     def shard=(new_shard)
@@ -28,21 +79,6 @@ module ActiveRecordShards
 
     def on_slave=(new_slave)
       @on_slave = (new_slave == true)
-    end
-
-    def shard_name(klass = nil, try_slave = true)
-      the_shard = shard(klass)
-
-      @shard_names ||= {}
-      @shard_names[ActiveRecordShards.rails_env] ||= {}
-      @shard_names[ActiveRecordShards.rails_env][the_shard] ||= {}
-      @shard_names[ActiveRecordShards.rails_env][the_shard][try_slave] ||= {}
-      @shard_names[ActiveRecordShards.rails_env][the_shard][try_slave][@on_slave] ||= begin
-        s = ActiveRecordShards.rails_env.dup
-        s << "_shard_#{the_shard}" if the_shard
-        s << "_slave"              if @on_slave && try_slave
-        s
-      end
     end
 
     def options


### PR DESCRIPTION
Thanks to @osheroff for doing the heavy lifting in #68. But while that PR changed ActiveRecordShards to work only on Rails 5, this PR keeps compatibility with Rails 3.2 and forward.