### PR TITLE
Reorganize code

### DIFF
--- a/lib/active_record_shards-3-2.rb
+++ b/lib/active_record_shards-3-2.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'active_record_shards/connection_pool'
+require 'active_record_shards/configuration_parser'
+require 'active_record_shards/model'
+require 'active_record_shards/shard_selection'
+require 'active_record_shards/connection_switcher'
+require 'active_record_shards/migration'
+require 'active_record_shards/default_slave_patches'
+require 'active_record_shards/association_collection_connection_selection'
+require 'active_record_shards/connection_handler'
+require 'active_record_shards/connection_specification'
+
+
+ActiveRecordShards::ConnectionSpecification = ActiveRecord::Base::ConnectionSpecification
+methods_to_override = [:remove_connection]
+ActiveRecordShards.override_connection_handler_methods(methods_to_override)
+
+ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
+ActiveRecord::Base.extend(ActiveRecordShards::Model)
+ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
+
+ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
+ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
+ActiveRecord::Associations::Preloader::HasAndBelongsToMany.include(ActiveRecordShards::DefaultSlavePatches::HasAndBelongsToManyPreloaderPatches)
+
+ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)
+
+
+
+ActiveRecord::Base.singleton_class.class_eval do
+  def establish_connection_with_connection_pool_name(spec = nil)
+    case spec
+    when ActiveRecordShards::ConnectionSpecification
+      connection_handler.establish_connection(connection_pool_name, spec)
+    else
+      establish_connection_without_connection_pool_name(spec)
+    end
+  end
+  alias_method :establish_connection_without_connection_pool_name, :establish_connection
+  alias_method :establish_connection, :establish_connection_with_connection_pool_name
+end

--- a/lib/active_record_shards-3-2.rb
+++ b/lib/active_record_shards-3-2.rb
@@ -1,41 +1,8 @@
 # frozen_string_literal: true
-require 'active_record_shards/connection_pool'
-require 'active_record_shards/configuration_parser'
-require 'active_record_shards/model'
-require 'active_record_shards/shard_selection'
-require 'active_record_shards/connection_switcher'
-require 'active_record_shards/migration'
-require 'active_record_shards/default_slave_patches'
-require 'active_record_shards/association_collection_connection_selection'
-require 'active_record_shards/connection_handler'
-require 'active_record_shards/connection_specification'
 
 
 ActiveRecordShards::ConnectionSpecification = ActiveRecord::Base::ConnectionSpecification
 methods_to_override = [:remove_connection]
 ActiveRecordShards.override_connection_handler_methods(methods_to_override)
 
-ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
-ActiveRecord::Base.extend(ActiveRecordShards::Model)
-ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
-
-ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
-ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
 ActiveRecord::Associations::Preloader::HasAndBelongsToMany.include(ActiveRecordShards::DefaultSlavePatches::HasAndBelongsToManyPreloaderPatches)
-
-ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)
-
-
-
-ActiveRecord::Base.singleton_class.class_eval do
-  def establish_connection_with_connection_pool_name(spec = nil)
-    case spec
-    when ActiveRecordShards::ConnectionSpecification
-      connection_handler.establish_connection(connection_pool_name, spec)
-    else
-      establish_connection_without_connection_pool_name(spec)
-    end
-  end
-  alias_method :establish_connection_without_connection_pool_name, :establish_connection
-  alias_method :establish_connection, :establish_connection_with_connection_pool_name
-end

--- a/lib/active_record_shards-4-0.rb
+++ b/lib/active_record_shards-4-0.rb
@@ -1,41 +1,10 @@
 # frozen_string_literal: true
-require 'active_record_shards/connection_pool'
-require 'active_record_shards/configuration_parser'
-require 'active_record_shards/model'
-require 'active_record_shards/shard_selection'
-require 'active_record_shards/connection_switcher'
-require 'active_record_shards/migration'
-require 'active_record_shards/default_slave_patches'
-require 'active_record_shards/association_collection_connection_selection'
-require 'active_record_shards/connection_handler'
-require 'active_record_shards/connection_specification'
 require 'active_record_shards/schema_dumper_extension'
 
 ActiveRecordShards::ConnectionSpecification = ActiveRecord::ConnectionAdapters::ConnectionSpecification
 methods_to_override = [:establish_connection, :remove_connection, :pool_for, :pool_from_any_process_for]
 ActiveRecordShards.override_connection_handler_methods(methods_to_override)
 
-ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
-ActiveRecord::Base.extend(ActiveRecordShards::Model)
-ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
-
-ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
-ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
 ActiveRecord::Associations::Preloader::HasAndBelongsToMany.include(ActiveRecordShards::DefaultSlavePatches::HasAndBelongsToManyPreloaderPatches)
 
-ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)
-
 ActiveRecord::SchemaDumper.prepend(ActiveRecordShards::SchemaDumperExtension)
-
-ActiveRecord::Base.singleton_class.class_eval do
-  def establish_connection_with_connection_pool_name(spec = nil)
-    case spec
-    when ActiveRecordShards::ConnectionSpecification
-      connection_handler.establish_connection(connection_pool_name, spec)
-    else
-      establish_connection_without_connection_pool_name(spec)
-    end
-  end
-  alias_method :establish_connection_without_connection_pool_name, :establish_connection
-  alias_method :establish_connection, :establish_connection_with_connection_pool_name
-end

--- a/lib/active_record_shards-4-0.rb
+++ b/lib/active_record_shards-4-0.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'active_record_shards/connection_pool'
+require 'active_record_shards/configuration_parser'
+require 'active_record_shards/model'
+require 'active_record_shards/shard_selection'
+require 'active_record_shards/connection_switcher'
+require 'active_record_shards/migration'
+require 'active_record_shards/default_slave_patches'
+require 'active_record_shards/association_collection_connection_selection'
+require 'active_record_shards/connection_handler'
+require 'active_record_shards/connection_specification'
+require 'active_record_shards/schema_dumper_extension'
+
+ActiveRecordShards::ConnectionSpecification = ActiveRecord::ConnectionAdapters::ConnectionSpecification
+methods_to_override = [:establish_connection, :remove_connection, :pool_for, :pool_from_any_process_for]
+ActiveRecordShards.override_connection_handler_methods(methods_to_override)
+
+ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
+ActiveRecord::Base.extend(ActiveRecordShards::Model)
+ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
+
+ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
+ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
+ActiveRecord::Associations::Preloader::HasAndBelongsToMany.include(ActiveRecordShards::DefaultSlavePatches::HasAndBelongsToManyPreloaderPatches)
+
+ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)
+
+ActiveRecord::SchemaDumper.prepend(ActiveRecordShards::SchemaDumperExtension)
+
+ActiveRecord::Base.singleton_class.class_eval do
+  def establish_connection_with_connection_pool_name(spec = nil)
+    case spec
+    when ActiveRecordShards::ConnectionSpecification
+      connection_handler.establish_connection(connection_pool_name, spec)
+    else
+      establish_connection_without_connection_pool_name(spec)
+    end
+  end
+  alias_method :establish_connection_without_connection_pool_name, :establish_connection
+  alias_method :establish_connection, :establish_connection_with_connection_pool_name
+end

--- a/lib/active_record_shards-4-1.rb
+++ b/lib/active_record_shards-4-1.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'active_record_shards/connection_pool'
+require 'active_record_shards/configuration_parser'
+require 'active_record_shards/model'
+require 'active_record_shards/shard_selection'
+require 'active_record_shards/connection_switcher'
+require 'active_record_shards/migration'
+require 'active_record_shards/default_slave_patches'
+require 'active_record_shards/association_collection_connection_selection'
+require 'active_record_shards/connection_handler'
+require 'active_record_shards/connection_specification'
+require 'active_record_shards/schema_dumper_extension'
+
+ActiveRecordShards::ConnectionSpecification = ActiveRecord::ConnectionAdapters::ConnectionSpecification
+methods_to_override = [:establish_connection, :remove_connection, :pool_for, :pool_from_any_process_for]
+ActiveRecordShards.override_connection_handler_methods(methods_to_override)
+
+ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
+ActiveRecord::Base.extend(ActiveRecordShards::Model)
+ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
+
+ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
+ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
+ActiveRecord::Associations::Builder::HasAndBelongsToMany.include(ActiveRecordShards::DefaultSlavePatches::Rails41HasAndBelongsToManyBuilderExtension)
+
+ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)
+
+ActiveRecord::SchemaDumper.prepend(ActiveRecordShards::SchemaDumperExtension)
+
+ActiveRecord::Base.singleton_class.class_eval do
+  def establish_connection_with_connection_pool_name(spec = nil)
+    case spec
+    when ActiveRecordShards::ConnectionSpecification
+      connection_handler.establish_connection(connection_pool_name, spec)
+    else
+      establish_connection_without_connection_pool_name(spec)
+    end
+  end
+  alias_method :establish_connection_without_connection_pool_name, :establish_connection
+  alias_method :establish_connection, :establish_connection_with_connection_pool_name
+end

--- a/lib/active_record_shards-4-1.rb
+++ b/lib/active_record_shards-4-1.rb
@@ -1,41 +1,10 @@
 # frozen_string_literal: true
-require 'active_record_shards/connection_pool'
-require 'active_record_shards/configuration_parser'
-require 'active_record_shards/model'
-require 'active_record_shards/shard_selection'
-require 'active_record_shards/connection_switcher'
-require 'active_record_shards/migration'
-require 'active_record_shards/default_slave_patches'
-require 'active_record_shards/association_collection_connection_selection'
-require 'active_record_shards/connection_handler'
-require 'active_record_shards/connection_specification'
 require 'active_record_shards/schema_dumper_extension'
 
 ActiveRecordShards::ConnectionSpecification = ActiveRecord::ConnectionAdapters::ConnectionSpecification
 methods_to_override = [:establish_connection, :remove_connection, :pool_for, :pool_from_any_process_for]
 ActiveRecordShards.override_connection_handler_methods(methods_to_override)
 
-ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
-ActiveRecord::Base.extend(ActiveRecordShards::Model)
-ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
-
-ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
-ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
 ActiveRecord::Associations::Builder::HasAndBelongsToMany.include(ActiveRecordShards::DefaultSlavePatches::Rails41HasAndBelongsToManyBuilderExtension)
 
-ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)
-
 ActiveRecord::SchemaDumper.prepend(ActiveRecordShards::SchemaDumperExtension)
-
-ActiveRecord::Base.singleton_class.class_eval do
-  def establish_connection_with_connection_pool_name(spec = nil)
-    case spec
-    when ActiveRecordShards::ConnectionSpecification
-      connection_handler.establish_connection(connection_pool_name, spec)
-    else
-      establish_connection_without_connection_pool_name(spec)
-    end
-  end
-  alias_method :establish_connection_without_connection_pool_name, :establish_connection
-  alias_method :establish_connection, :establish_connection_with_connection_pool_name
-end

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 require 'active_record'
 require 'active_record/base'
+require 'active_record_shards/configuration_parser'
+require 'active_record_shards/model'
+require 'active_record_shards/shard_selection'
+require 'active_record_shards/connection_switcher'
+require 'active_record_shards/association_collection_connection_selection'
+require 'active_record_shards/connection_pool'
+require 'active_record_shards/migration'
+require 'active_record_shards/default_slave_patches'
+require 'active_record_shards/connection_handler'
+require 'active_record_shards/connection_specification'
 
 module ActiveRecordShards
   def self.rails_env
@@ -9,6 +19,26 @@ module ActiveRecordShards
     env ||= ENV['RAILS_ENV']
     env ||= 'development'
   end
+end
+
+ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
+ActiveRecord::Base.extend(ActiveRecordShards::Model)
+ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
+ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
+ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
+ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)
+
+ActiveRecord::Base.singleton_class.class_eval do
+  def establish_connection_with_connection_pool_name(spec = nil)
+    case spec
+    when ActiveRecordShards::ConnectionSpecification
+      connection_handler.establish_connection(connection_pool_name, spec)
+    else
+      establish_connection_without_connection_pool_name(spec)
+    end
+  end
+  alias_method :establish_connection_without_connection_pool_name, :establish_connection
+  alias_method :establish_connection, :establish_connection_with_connection_pool_name
 end
 
 case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -1,51 +1,6 @@
 # frozen_string_literal: true
 require 'active_record'
 require 'active_record/base'
-require 'active_record_shards/configuration_parser'
-require 'active_record_shards/model'
-require 'active_record_shards/shard_selection'
-require 'active_record_shards/connection_switcher'
-require 'active_record_shards/association_collection_connection_selection'
-require 'active_record_shards/connection_pool'
-require 'active_record_shards/migration'
-require 'active_record_shards/default_slave_patches'
-require 'active_record_shards/connection_handler'
-require 'active_record_shards/connection_specification'
-require 'active_record_shards/schema_dumper_extension'
-
-if ActiveRecord::VERSION::MAJOR >= 4
-  methods_to_override = [:establish_connection, :remove_connection, :pool_for,
-                         :pool_from_any_process_for]
-  ActiveRecordShards::ConnectionSpecification = ActiveRecord::ConnectionAdapters::ConnectionSpecification
-else
-  methods_to_override = [:remove_connection]
-  ActiveRecordShards::ConnectionSpecification = ActiveRecord::Base::ConnectionSpecification
-end
-
-ActiveRecordShards.override_connection_handler_methods(methods_to_override)
-
-ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
-ActiveRecord::Base.extend(ActiveRecordShards::Model)
-ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
-ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
-
-if ActiveRecord.const_defined?(:Relation)
-  ActiveRecord::Relation.send(:include, ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
-end
-
-if ActiveRecord::Associations.const_defined?(:Preloader) && ActiveRecord::Associations::Preloader.const_defined?(:HasAndBelongsToMany)
-  ActiveRecord::Associations::Preloader::HasAndBelongsToMany.send(:include, ActiveRecordShards::DefaultSlavePatches::HasAndBelongsToManyPreloaderPatches)
-end
-
-if ActiveRecord::VERSION::STRING >= '4.1.0'
-  ActiveRecord::Associations::Builder::HasAndBelongsToMany.send(:include, ActiveRecordShards::DefaultSlavePatches::Rails41HasAndBelongsToManyBuilderExtension)
-end
-
-ActiveRecord::Associations::CollectionProxy.send(:include, ActiveRecordShards::AssociationCollectionConnectionSelection)
-
-if ActiveRecord::VERSION::MAJOR >= 4
-  ActiveRecord::SchemaDumper.send(:prepend, ActiveRecordShards::SchemaDumperExtension)
-end
 
 module ActiveRecordShards
   def self.rails_env
@@ -56,15 +11,11 @@ module ActiveRecordShards
   end
 end
 
-ActiveRecord::Base.singleton_class.class_eval do
-  def establish_connection_with_connection_pool_name(spec = nil)
-    case spec
-    when ActiveRecordShards::ConnectionSpecification
-      connection_handler.establish_connection(connection_pool_name, spec)
-    else
-      establish_connection_without_connection_pool_name(spec)
-    end
-  end
-  alias_method :establish_connection_without_connection_pool_name, :establish_connection
-  alias_method :establish_connection, :establish_connection_with_connection_pool_name
+case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+when '3.2'
+  require 'active_record_shards-3-2'
+when '4.0'
+  require 'active_record_shards-4-0'
+when '4.1', '4.2', '5.0'
+  require 'active_record_shards-4-1'
 end


### PR DESCRIPTION
Create a file for patching each different version of `ActiveRecord`. With a growing number of ActiveRecord versions to support, I think we need to clean up our patches somehow.

What do you think, @osheroff, @grosser & @pschambacher?