### PR TITLE
only do a short rescue for know errors, everything else shows long error

### DIFF
--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -12,8 +12,11 @@ namespace :db do
       if key.starts_with?(ActiveRecordShards.rails_env) && !key.ends_with?("_slave")
         begin
           ActiveRecordShards::Tasks.root_connection(conf).drop_database(conf['database'])
-        rescue Exception => e
-          puts "Couldn't drop #{conf['database']} : #{e.inspect}"
+        # rescue ActiveRecord::NoDatabaseError # TODO: exists in AR but never is raised here ...
+        #   $stderr.puts "Database '#{conf['database']}' does not exist"
+        rescue Exception => error
+          $stderr.puts error, *(error.backtrace)
+          $stderr.puts "Couldn't drop #{conf['database']}"
         end
       end
     end

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -7,6 +7,14 @@ Rake::Application.new.rake_require("active_record/railties/databases")
 require 'active_record_shards/tasks'
 
 describe "Database rake tasks" do
+  def capture_stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = STDERR
+  end
+
   let(:config) { Phenix.load_database_config('test/database_tasks.yml') }
   let(:master_name) { config['test']['database'] }
   let(:slave_name) { config['test']['slave']['database'] }
@@ -52,6 +60,19 @@ describe "Database rake tasks" do
       shard_names.each do |name|
         refute_includes databases, name
       end
+    end
+
+    it "does not fail when db is missing" do
+      rake('db:create')
+      rake('db:drop')
+      show_databases(config).wont_include master_name
+    end
+
+    it "fails loudly when unknown error occurs" do
+      ActiveRecordShards::Tasks.stubs(:root_connection).raises(ArgumentError)
+      out = capture_stderr { rake('db:drop') }
+      out.must_include "Couldn't drop "
+      out.must_include "test/helper.rb"
     end
   end
 end


### PR DESCRIPTION
makes it easier to debug nasty issues and gets it closer to what rails is doing

https://github.com/rails/rails/blob/028748945b7a3bb15555b90a58905190c601a15b/activerecord/lib/active_record/tasks/database_tasks.rb#L134-L144

@osheroff @bquorning @pschambacher 