### PR TITLE
`logging_query_plan` uses slave connection by default in Rails 3

### DIFF
--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -96,6 +96,13 @@ module ActiveRecordShards
         [:calculate, :exists?, :pluck, :find_with_associations].each do |m|
           ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, m)
         end
+
+        # ActiveRecord::Explain in v3 will eagerly establish an on_master
+        # connection just to just the _static_ `supports_explain?` method on
+        # the Mysql2Adapter
+        if ActiveRecord::VERSION::MAJOR == 3
+          ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :logging_query_plan)
+        end
       end
 
       def on_slave_unless_tx

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -484,6 +484,17 @@ describe "connection switching" do
           assert_equal 'master_name', account.reload.name
         end
 
+        if ActiveRecord::VERSION::MAJOR == 3
+          it "logging_query_plan does not checkout master connection" do
+            # This method is called on #to_a, and is implemented on the
+            # Mysql2Adapter as a static boolean, but will trigger a connection
+            # to the master.
+            Account.on_master.connection.expects(:supports_explain?).never
+            Account.on_slave.connection.expects(:supports_explain?).at_least_once
+            Account.where(id: 1000).to_a
+          end
+        end
+
         it "do exists? on the slave" do
           if Account.respond_to?(:exists?)
             assert Account.exists?(1001)


### PR DESCRIPTION
We have an initializer that fetches records from the database. In Rails 3.2, this will eagerly open a connection to the master database, which in our case requires going across the WAN. It opens a connection to the database exclusively to call a static method. This can cause the application to crash on startup if the WAN is experiencing availability problems. This behavior is not present in Rails 4.

Here's a relevant backtrace from byebug, captured with a `break Mysql2::Client#initialize` 

```
--> #0  Mysql2::Client.initialize(opts#Hash) at /usr/local/lib/ruby/gems/2.1.0/gems/mysql2-0.3.20/lib/mysql2/client.rb:18
    ͱ-- #1  Class.new(*args) at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/mysql2_adapter.rb:16
    #2  #<Class:ActiveRecord::Base>.mysql2_connection(config#Hash) at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/mysql2_adapter.rb:16
    #3  #<Class:ActiveRecord::Base>.mysql2_connection_with_symbolize_keys(config#Hash) at /usr/local/lib/ruby/gems/2.1.0/gems/zendesk_database_support-1.23.0/lib/zendesk_database_support/fix_mysql2_symbolized_keys.rb:8
    #4  ActiveRecord::ConnectionAdapters::ConnectionPool.new_connection at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:315
    #5  ActiveRecord::ConnectionAdapters::ConnectionPool.checkout_new_connection at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:325
    #6  block (2 levels) in ActiveRecord::ConnectionAdapters::ConnectionPool.block (2 levels) in checkout at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:247
    ͱ-- #7  Kernel.loop at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:242
    #8  block in ActiveRecord::ConnectionAdapters::ConnectionPool.block in checkout at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:242
    #9  MonitorMixin.mon_synchronize at /usr/local/lib/ruby/2.1.0/monitor.rb:211
    #10 ActiveRecord::ConnectionAdapters::ConnectionPool.checkout at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:239
    #11 block in ActiveRecord::ConnectionAdapters::ConnectionPool.block in connection at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:102
    #12 MonitorMixin.mon_synchronize at /usr/local/lib/ruby/2.1.0/monitor.rb:211
    #13 ActiveRecord::ConnectionAdapters::ConnectionPool.connection at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:101
    #14 ActiveRecordHostPool::PoolProxy.connection(*args#Array) at /usr/local/lib/ruby/gems/2.1.0/gems/active_record_host_pool-0.9.4/lib/active_record_host_pool/pool_proxy.rb:38
    #15 ActiveRecord::ConnectionAdapters::ConnectionHandler.retrieve_connection(klass#Class) at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_pool.rb:410
    #16 #<Class:ActiveRecord::Base>.retrieve_connection at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_specification.rb:171
    #17 #<Class:ActiveRecord::Base>.connection at /bundle/gems/activerecord-3.2.22.3/lib/active_record/connection_adapters/abstract/connection_specification.rb:145
    #18 ActiveRecord::Delegation.connection(*args#Array, &block#NilClass) at /bundle/gems/activerecord-3.2.22.3/lib/active_record/relation/delegation.rb:7
    #19 ActiveRecord::Explain.logging_query_plan at /bundle/gems/activerecord-3.2.22.3/lib/active_record/explain.rb:30
    #20 ActiveRecord::Relation.to_a at /bundle/gems/activerecord-3.2.22.3/lib/active_record/relation.rb:159
    #21 PredictiveLoad::ActiveRecordCollectionObservation::RelationObservation.to_a_with_collection_observer at /usr/local/lib/ruby/gems/2.1.0/gems/predictive_load-0.3.2/lib/predictive_load/active_record_collection_observation.rb:19
    #22 ActiveRecord::FinderMethods.find_first at /bundle/gems/activerecord-3.2.22.3/lib/active_record/relation/finder_methods.rb:381
    #23 ActiveRecord::FinderMethods.first(*args#Array) at /bundle/gems/activerecord-3.2.22.3/lib/active_record/relation/finder_methods.rb:122
    #24 ActiveRecord::FinderMethods.find_by_attributes(match#ActiveRecord::DynamicFinderMatch, attributes#Array, *args#Array) at /bundle/gems/activerecord-3.2.22.3/lib/active_record/relation/finder_methods.rb:267
```

Interesting bits:

- https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/relation.rb#L159
- https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/explain.rb#L30
- https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L39

/cc @zendesk/infrastructure 