### PR TITLE
stop creating read-only scopes

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -100,7 +100,7 @@ module ActiveRecordShards
     alias_method :with_slave_if, :on_slave_if
     alias_method :with_slave_unless, :on_slave_unless
 
-    def on_cx_switch_block(which, force: false, construct_ro_scope: nil, &block)
+    def on_cx_switch_block(which, force: false)
       @disallow_slave ||= 0
       @disallow_slave += 1 if which == :master
 

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -109,13 +109,7 @@ module ActiveRecordShards
 
       switch_connection(slave: switch_to_slave)
 
-      # we avoid_readonly_scope to prevent some stack overflow problems, like when
-      # .columns calls .with_scope which calls .columns and onward, endlessly.
-      if self == ActiveRecord::Base || !switch_to_slave || construct_ro_scope == false
-        yield
-      else
-        readonly.scoping(&block)
-      end
+      yield
     ensure
       @disallow_slave -= 1 if which == :master
       switch_connection(old_options) if old_options

--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -26,13 +26,13 @@ module ActiveRecordShards
     end
 
     def columns_with_force_slave(*args, &block)
-      on_cx_switch_block(:slave, construct_ro_scope: false, force: true) do
+      on_cx_switch_block(:slave, force: true) do
         columns_without_force_slave(*args, &block)
       end
     end
 
     def table_exists_with_force_slave?(*args, &block)
-      on_cx_switch_block(:slave, construct_ro_scope: false, force: true) do
+      on_cx_switch_block(:slave, force: true) do
         table_exists_without_force_slave?(*args, &block)
       end
     end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -473,14 +473,6 @@ describe "connection switching" do
           assert_equal('master_name', @model.name)
         end
 
-        it "be marked as read only" do
-          if ActiveRecord::VERSION::STRING >= '4.2.0'
-            skip("Readonly scope on finder method is complicated on Rails 4.2")
-          end
-
-          assert(@model.readonly?)
-        end
-
         it "be marked as comming from the slave" do
           assert(@model.from_slave?)
         end
@@ -504,15 +496,6 @@ describe "connection switching" do
           @model = Account.first
           assert(@model)
           assert_equal('master_name', @model.name)
-        end
-
-        it "not unset readonly" do
-          @model = Account.on_master.readonly.first
-          assert(@model.readonly?)
-        end
-
-        it "not be marked as read only" do
-          assert(!@model.readonly?)
         end
 
         it "not be marked as comming from the slave" do


### PR DESCRIPTION
opening a PR to collect test failures.  

It's unclear whether the readonly scope ever really saved us anything, and after a97e981 too much stuff creates a slave-scope, causing test failures and such. 

@gabetax @prudhvi 
