### PR TITLE
Raise AR::AdapterNotSpecified, not RuntimeError

### DIFF
--- a/lib/active_record_shards/connection_switcher-4-0.rb
+++ b/lib/active_record_shards/connection_switcher-4-0.rb
@@ -21,7 +21,9 @@ module ActiveRecordShards
       name = connection_pool_name
       spec = configurations[name]
 
-      raise(ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in database.yml") if spec.nil?
+      if spec.nil?
+        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in database.yml"
+      end
 
       # in 3.2 rails is asking for a connection pool in a map of these ConnectionSpecifications.  If we want to re-use connections,
       # we need to re-use specs.

--- a/lib/active_record_shards/connection_switcher-5-0.rb
+++ b/lib/active_record_shards/connection_switcher-5-0.rb
@@ -3,7 +3,10 @@ module ActiveRecordShards
     def connection_specification_name
       name = current_shard_selection.resolve_connection_name(sharded: is_sharded?, configurations: configurations)
 
-      raise "No configuration found for #{name}" unless configurations[name] || name == "primary"
+      unless configurations[name] || name == "primary"
+        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in database.yml"
+      end
+
       name
     end
 


### PR DESCRIPTION
If the database configuration cannot be found with Rails 4, we have always raised an `ActiveRecord::AdapterNotSpecified` exception. Using Rails 5, we started raising a `RuntimeError` instead.

With this commit, we will raise an `ActiveRecord::AdapterNotSpecified` exception no matter which version of Rails you are using.

cc @osheroff @jacobat @dasch @grosser @pschambacher 