### PR TITLE
Compatibility with Rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1.10
+  - 2.2.4
+  - 2.3.3
+  - 2.4.0
 gemfile:
   - gemfiles/rails3.2.gemfile
-  - gemfiles/rails4.0.gemfile
-  - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
+  - gemfiles/rails5.1.gemfile
 bundler_args: --no-deployment
 script:
   - bundle exec rake rubocop
@@ -21,5 +21,9 @@ branches:
     - 3-7-0
 matrix:
   exclude:
-    - rvm: 2.1.9
+    - rvm: 2.4.0
+      gemfile: gemfiles/rails3.2.gemfile
+    - rvm: 2.1.10
       gemfile: gemfiles/rails5.0.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails5.1.gemfile

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new "active_record_shards", "3.7.3" do |s|
 
   s.required_ruby_version = "~> 2.0"
 
-  s.add_runtime_dependency("activerecord", ">= 3.2.16", "< 5.1")
-  s.add_runtime_dependency("activesupport", ">= 3.2.16", "< 5.1")
+  s.add_runtime_dependency("activerecord", ">= 3.2.16", "< 5.2")
+  s.add_runtime_dependency("activesupport", ">= 3.2.16", "< 5.2")
 
   s.add_development_dependency("wwtd")
   s.add_development_dependency("rake")

--- a/gemfiles/rails4.0.gemfile
+++ b/gemfiles/rails4.0.gemfile
@@ -1,4 +1,0 @@
-eval_gemfile 'gemfiles/common.rb'
-
-gem 'activerecord', '~> 4.0.10'
-gem 'mysql2', '~> 0.3.0'

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -1,4 +1,0 @@
-eval_gemfile 'gemfiles/common.rb'
-
-gem 'activerecord', '~> 4.1.0'
-gem 'mysql2', '~> 0.3.0'

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile 'gemfiles/common.rb'
+
+gem 'activerecord', '~> 5.1.0.beta1'

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -32,7 +32,7 @@ when '4.0'
   require 'active_record_shards-4-0'
 when '4.1', '4.2'
   require 'active_record_shards-4-1'
-when '5.0'
+when '5.0', '5.1'
   require 'active_record_shards-5-0'
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"

--- a/lib/active_record_shards/connection_switcher-5-0.rb
+++ b/lib/active_record_shards/connection_switcher-5-0.rb
@@ -20,9 +20,16 @@ module ActiveRecordShards
 
       pool = connection_handler.retrieve_connection_pool(spec_name)
       if pool.nil?
-        resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new configurations
-        spec = resolver.spec(spec_name.to_sym, spec_name)
-        connection_handler.establish_connection spec
+        spec =
+          if ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR.zero?
+            resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(configurations)
+            resolver.spec(spec_name.to_sym, spec_name)
+          else
+            # Resolver will be applied by Rails 5.1+
+            spec_name.to_sym
+          end
+
+        connection_handler.establish_connection(spec)
       end
     end
   end

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -190,7 +190,7 @@ end
 case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
 when '3.2', '4.0', '4.1', '4.2'
   require 'active_record_shards/connection_switcher-4-0'
-when '5.0'
+when '5.0', '5.1'
   require 'active_record_shards/connection_switcher-5-0'
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"


### PR DESCRIPTION
/cc @zendesk/zendesk-rails-upgraders 

Only remarkable change: calling `establish_connection` will now automatically call the Resolver so we don't need to do it.