### PR TITLE
schema_migrations_table_name is deprecated in 5.1

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -158,11 +158,21 @@ module ActiveRecordShards
       ActiveRecordShards.rails_env
     end
 
-    def with_default_shard
-      if is_sharded? && current_shard_id.nil? && table_name != ActiveRecord::Migrator.schema_migrations_table_name
-        on_first_shard { yield }
-      else
-        yield
+    if ActiveRecord::VERSION::MAJOR >= 4
+      def with_default_shard
+        if is_sharded? && current_shard_id.nil? && table_name != ActiveRecord::SchemaMigration.table_name
+          on_first_shard { yield }
+        else
+          yield
+        end
+      end
+    else
+      def with_default_shard
+        if is_sharded? && current_shard_id.nil? && table_name != ActiveRecord::Migrator.schema_migrations_table_name
+          on_first_shard { yield }
+        else
+          yield
+        end
       end
     end
 


### PR DESCRIPTION
In https://github.com/rails/rails/commit/67fba0cfa93feaa183d546de625e63cb16c56d `SchemaMigration` model was extracted, so we have `ActiveRecord::SchemaMigration.table_name` to use instead. In https://github.com/rails/rails/commit/96aa18974adf7321f265ea `schema_migrations_table_name` was deprecated.