### PR TITLE
Fix catch of existing DB error from postgres

### DIFF
--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -39,7 +39,7 @@ namespace :db do
 
           ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'], symbolized_configuration)
         rescue ActiveRecord::StatementInvalid => ex
-          if ex.message.include?('database exists')
+          if ex.message[/database.*exists/]
             puts "#{conf['database']} already exists"
           else
             raise ex


### PR DESCRIPTION
To avoid postgres:
```
vagrant@vagrant-ubuntu-trusty-64:/cloudcxo$ rake db:create RAILS_ENV=development
rake aborted!
ActiveRecord::StatementInvalid: PG::DuplicateDatabase: ERROR:  database "development" already exists
: CREATE DATABASE "development" ENCODING = 'utf8'
/home/vagrant/.bundler/ruby/2.3.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:98:in `async_exec'
/home/vagrant/.bundler/ruby/2.3.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:98:in `block in execute'
/home/vagrant/.bundler/ruby/2.3.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
/home/vagrant/.bundler/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/vagrant/.bundler/ruby/2.3.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
/home/vagrant/.bundler/ruby/2.3.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:97:in `execute'
/home/vagrant/.bundler/ruby/2.3.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/postgresql/schema_statements.rb:62:in `create_database'
/home/vagrant/.bundler/ruby/2.3.0/gems/active_record_shards-3.9.0/lib/active_record_shards/tasks.rb:40:in `block (3 levels) in <top (required)>'
/home/vagrant/.bundler/ruby/2.3.0/gems/active_record_shards-3.9.0/lib/active_record_shards/tasks.rb:31:in `each'
/home/vagrant/.bundler/ruby/2.3.0/gems/active_record_shards-3.9.0/lib/active_record_shards/tasks.rb:31:in `block (2 levels) in <top (required)>'
/home/vagrant/.bundler/ruby/2.3.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
```