### PR TITLE
Root and all

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ This will perform the query on the slave, and mark the returned instances as rea
 
     Account.on_slave.find_by_big_expensive_query
 
+## Migrations
+
+Your migrations must specify which databases (root and/or shards) the migration
+applies to, so you must add `shard(X)` where X is one of:
+
+  * :none (apply this migration to the root database, not the shards)
+  * :all (apply this migration to all shards, not the root)
+  * <name> (apply this migration to a named shard, for data fixups)
+  * :root_and_all (apply this migration to the root database and all the shards)
+
 ## Copyright
 
 Copyright (c) 2011 Zendesk. See LICENSE for details.

--- a/lib/active_record_shards/migration.rb
+++ b/lib/active_record_shards/migration.rb
@@ -88,17 +88,17 @@ module ActiveRecordShards
   module ActualMigrationExtension
     def migrate_with_forced_shard(direction)
       if migration_shard.blank?
-        raise "#{name}: Can't run migrations without a shard spec: this may be :all, :none,
-                 or a specific shard (for data-fixups).  please call shard(arg) in your migration."
+        raise "#{name}: Can't run migrations without a shard spec: this may be :all, :none, :root_and_all
+                 or a specific shard (for data-fixups).  Please call shard(arg) in your migration."
       end
 
       shard = ActiveRecord::Base.current_shard_selection.shard
 
       if shard.nil?
-        return if migration_shard != :none
+        return if migration_shard != :none && migration_shard != :root_and_all
       else
         return if migration_shard == :none
-        return if migration_shard != :all && migration_shard.to_s != shard.to_s
+        return if migration_shard != :all && migration_shard.to_s != shard.to_s && migration_shard != :root_and_all
       end
 
       migrate_without_forced_shard(direction)

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -39,7 +39,7 @@ namespace :db do
 
           ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'], symbolized_configuration)
         rescue ActiveRecord::StatementInvalid => ex
-          if ex.message.include?('database exists')
+          if ex.message[/database.*exists/]
             puts "#{conf['database']} already exists"
           else
             raise ex

--- a/test/migrations/20170327162001_root_and_all_migration.rb
+++ b/test/migrations/20170327162001_root_and_all_migration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class RootAndAllMigration < BaseMigration
+  shard :root_and_all
+
+  def self.up
+    add_column :accounts, :root_and_all_column, :integer
+  end
+
+  def self.down
+    remove_column :accounts, :root_and_all_column
+  end
+end


### PR DESCRIPTION
This allows migrations to run against the root and all the shards.

We have a couple of tables that need to be replicated across the shards from the root database (to enable queries with joins against our ```user``` and ```organisation``` models). This extends the shards migration implementation slightly to enable that use-case.

I also added a little bit to the documentation to explain the migrations implementation.

Note that this PR is a branch from the #96 codeline so I can rebase this, once that one is merged.