### PR TITLE
Enable and fix `ruby -w` warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-eval_gemfile 'gemfiles/rails5.0.gemfile'
+eval_gemfile 'gemfiles/rails5.1.gemfile'

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.pattern = './test/**/*_test.rb'
   test.verbose = false
+  test.warning = true
 end
 
 task default: ["rubocop", "wwtd:local"]

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,6 @@ require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.pattern = './test/**/*_test.rb'
   test.verbose = false
-  test.warning = false
 end
 
 task default: ["rubocop", "wwtd:local"]

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new "active_record_shards", "3.9.0" do |s|
   s.add_runtime_dependency("activesupport", ">= 3.2.16", "< 5.2")
 
   s.add_development_dependency("wwtd")
-  s.add_development_dependency("rake")
+  s.add_development_dependency("rake", '~> 12.0')
   s.add_development_dependency("mysql2")
   s.add_development_dependency("bump")
   s.add_development_dependency("rubocop", "0.42.0")

--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -9,13 +9,14 @@ module ActiveRecordShards
     end
 
     def is_sharded? # rubocop:disable Style/PredicateName
+      sharded_ivar = defined?(@sharded) ? @sharded : nil
       if self == ActiveRecord::Base
-        @sharded != false && supports_sharding?
+        sharded_ivar != false && supports_sharding?
       elsif self == base_class
-        if @sharded.nil?
+        if sharded_ivar.nil?
           ActiveRecord::Base.is_sharded?
         else
-          @sharded != false
+          sharded_ivar != false
         end
       else
         base_class.is_sharded?
@@ -26,14 +27,10 @@ module ActiveRecordShards
       if self == ActiveRecord::Base
         false
       elsif self == base_class
-        @on_slave_by_default
+        on_slave_by_default
       else
         base_class.on_slave_by_default?
       end
-    end
-
-    def on_slave_by_default=(val)
-      @on_slave_by_default = val
     end
 
     module InstanceMethods
@@ -55,5 +52,11 @@ module ActiveRecordShards
       base.send(:include, InstanceMethods)
       base.after_initialize :initialize_shard_and_slave
     end
+
+    attr_writer :on_slave_by_default
+
+    private
+
+    attr_reader :on_slave_by_default
   end
 end

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -25,7 +25,7 @@ describe "Database rake tasks" do
     if ActiveRecord::VERSION::MAJOR >= 4
       ActiveRecord::Tasks::DatabaseTasks.database_configuration = config
       ActiveRecord::Tasks::DatabaseTasks.env = RAILS_ENV
-      ActiveRecord::Tasks::DatabaseTasks.migrations_paths = '/'
+      ActiveRecord::Tasks::DatabaseTasks.migrations_paths = '/app/migrations'
     else
       # It uses Rails.application.config to config ActiveRecord
       Rake::Task['db:load_config'].clear


### PR DESCRIPTION
### Description

Bumps rake to turn warnings on by default and removes the explicit disable. Also fixed the sources of warnings that are flooding the output in consumers of this.

Requesting reviews based on Github suggestions.

![screen shot 2017-03-29 at 3 21 41 pm](https://cloud.githubusercontent.com/assets/5535625/24438501/988d0526-1493-11e7-9e97-48f70a1e80d0.png)

### Risks
The tests work and the logic should be identical, I think the only thing to watch for with this bump is performance regressions due to slightly more indirect access.