### PR TITLE
Set primary key to 'id'

### DIFF
--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -48,29 +48,31 @@ module ActiveRecordShards
       end
     end
 
+    module PrimaryKeyWithDefault
+      # In a shared connection, ShardedModel.table_exists? will run on the first
+      # shard (because of ConnectionSwitcher#table_exists_with_default_shard), while
+      # ShardedModel.connection.table_exists?(sharded_table) will still run on the
+      # *shared* connection (and will return false, as the sharded table doesn't exist
+      # in the shared database). Among other potential issues, this behavior causes
+      # ActiveRecord to cache the sharded table primary_id as nil.
+      #
+      # Removing the with_default_shard behavior might cause issues, so instead
+      # we set primary_key as 'id'. Any model with a different primary key will
+      # need to explicit set it in the class definition.
+      def primary_key
+        # Do not call `super`, or it can trigger `stack level too deep` if some
+        # code alias_method chain `primay_key` later (e.g. new relic gem)
+        @primary_key ||= 'id'
+      end
+    end
+
     def self.extended(base)
       base.send(:include, InstanceMethods)
-      base.singleton_class.send(:alias_method, :primary_key_without_default_value, :primary_key)
-      base.singleton_class.send(:alias_method, :primary_key, :primary_key_with_default_value)
+      base.singleton_class.prepend PrimaryKeyWithDefault
       base.after_initialize :initialize_shard_and_slave
     end
 
     attr_writer :on_slave_by_default
-
-    # In a shared connection, ShardedModel.table_exists? will run on the first
-    # shard (because of ConnectionSwitcher#table_exists_with_default_shard), while
-    # ShardedModel.connection.table_exists?(sharded_table) will still run on the
-    # *shared* connection (and will return false, as the sharded table doesn't exist
-    # in the shared database). Among other potential issues, this behavior causes
-    # ActiveRecord to cache the sharded table primary_id as nil.
-    #
-    # Removing the with_default_shard behavior might cause issues, so instead
-    # we set primary_key as 'id'. Any model with a different primary key will
-    # need to explicit set it in the class definition.
-    def primary_key_with_default_value
-      @primary_key ||= 'id'
-      primary_key_without_default_value
-    end
 
     private
 

--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -50,10 +50,27 @@ module ActiveRecordShards
 
     def self.extended(base)
       base.send(:include, InstanceMethods)
+      base.singleton_class.send(:alias_method, :primary_key_without_default_value, :primary_key)
+      base.singleton_class.send(:alias_method, :primary_key, :primary_key_with_default_value)
       base.after_initialize :initialize_shard_and_slave
     end
 
     attr_writer :on_slave_by_default
+
+    # In a shared connection, ShardedModel.table_exists? will run on the first
+    # shard (because of ConnectionSwitcher#table_exists_with_default_shard), while
+    # ShardedModel.connection.table_exists?(sharded_table) will still run on the
+    # *shared* connection (and will return false, as the sharded table doesn't exist
+    # in the shared database). Among other potential issues, this behavior causes
+    # ActiveRecord to cache the sharded table primary_id as nil.
+    #
+    # Removing the with_default_shard behavior might cause issues, so instead
+    # we set primary_key as 'id'. Any model with a different primary key will
+    # need to explicit set it in the class definition.
+    def primary_key_with_default_value
+      @primary_key = 'id' unless defined? @primary_key
+      primary_key_without_default_value
+    end
 
     private
 

--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -68,7 +68,7 @@ module ActiveRecordShards
     # we set primary_key as 'id'. Any model with a different primary key will
     # need to explicit set it in the class definition.
     def primary_key_with_default_value
-      @primary_key = 'id' unless defined? @primary_key
+      @primary_key ||= 'id'
       primary_key_without_default_value
     end
 

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require File.expand_path('../helper', __FILE__)
+
+describe 'models' do
+  before do
+    Phenix.rise!(with_schema: true)
+    ActiveRecord::Base.establish_connection(RAILS_ENV.to_sym)
+    require 'models'
+  end
+
+  describe 'primary_key' do
+    it "should be set to 'id' by default" do
+      User.connection.expects(:execute).never
+      assert_equal 'id', User.primary_key
+    end
+
+    it 'should keep value if already set' do
+      class UniqueModel < ActiveRecord::Base
+        self.primary_key = 'model_id'
+      end
+
+      assert 'model_id', UniqueModel.primary_key
+    end
+  end
+end

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -19,7 +19,7 @@ describe 'models' do
         self.primary_key = 'model_id'
       end
 
-      assert 'model_id', UniqueModel.primary_key
+      assert_equal 'model_id', UniqueModel.primary_key
     end
   end
 end


### PR DESCRIPTION
/cc @grosser @bquorning @pschambacher @zendesk/sustaining @zendesk/i18n-dev 

Fixes UnknownPrimaryKey exceptions.

Issue:

* Shared and sharded connections to different servers / databases
* Request on the shared connection (on_shard never called)
* Within the request, ShardedModel.table_exists? will be executed on the first shard (ConnectionSwitcher#table_exists_with_default_shard) and return true
* Within the same request, ShardedModel.connection.schema_cache.table_exists? (`data_source_exists?` on rails 5) will execute on the shared connection and return false

That behavior has a direct impact on `primary_key` (using rails 4.2.8 as example, looking at the source code for rails 5 the behavior seems to still be the same):

* On a shared connection, calling ShardedModel.new will trigger ShardedModel.primary_key
* That will call [ActiveRecord:: AttributeMethods:: PrimaryKey#primary_key](https://github.com/rails/rails/blob/v4.2.8/activerecord/lib/active_record/attribute_methods/primary_key.rb#L72), which calls `reset_primary_key` and [table_exists?](https://github.com/rails/rails/blob/v4.2.8/activerecord/lib/active_record/attribute_methods/primary_key.rb#L97) (and because of ConnectionSwitcher#table_exists_with_default_shard, it'll return true)
* Then, [connection.schema_cache.primary_keys](https://github.com/rails/rails/blob/v4.2.8/activerecord/lib/active_record/connection_adapters/schema_cache.rb#L17) gets called on the *shared* connection, and `table_exists?(table_name)` within that method returns false, so `SchemaCache#primary_keys(table)` returns `nil` (which gets cached as ShardedModel's primary_key)
* Any subsequent request on the *sharded* connection that looks for SharedModel associations [fails with this exception](https://github.com/rails/rails/blob/v4.2.8/activerecord/lib/active_record/reflection.rb#L581

Talking to Grosser, ideally we would remove the with_default_shard behavior but that ofc might cause issues, so instead we set primary_key as 'id'. Any model with a different primary key will
need to explicit set it in the class definition. If other rails methods have similar issues to `primary_key`, we'll need to find workarounds for them as well.