### PR TITLE
Revert "`logging_query_plan` uses slave connection by default in Rails 3"

### DIFF
--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -98,13 +98,6 @@ module ActiveRecordShards
         [:calculate, :exists?, :pluck, :find_with_associations].each do |m|
           ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, m)
         end
-
-        # ActiveRecord::Explain in v3 will eagerly establish an on_master
-        # connection just to just the _static_ `supports_explain?` method on
-        # the Mysql2Adapter
-        if ActiveRecord::VERSION::MAJOR == 3
-          ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :logging_query_plan)
-        end
       end
 
       def on_slave_unless_tx

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -484,17 +484,6 @@ describe "connection switching" do
           assert_equal 'master_name', account.reload.name
         end
 
-        if ActiveRecord::VERSION::MAJOR == 3
-          it "logging_query_plan does not checkout master connection" do
-            # This method is called on #to_a, and is implemented on the
-            # Mysql2Adapter as a static boolean, but will trigger a connection
-            # to the master.
-            Account.on_master.connection.expects(:supports_explain?).never
-            Account.on_slave.connection.expects(:supports_explain?).at_least_once
-            Account.where(id: 1000).to_a
-          end
-        end
-
         it "do exists? on the slave" do
           if Account.respond_to?(:exists?)
             assert Account.exists?(1001)


### PR DESCRIPTION
Reverts zendesk/active_record_shards#82

/cc @grosser @gabetax @bquorning @craig-day 

This PR was meant for Classic and isn't used by any other application.
Sadly it also breaks Classic and after a couple hours of investigation... I wasn't able to find why. Gabe doesn't have time to investigate so I'd say... let's revert we can always come back later (meaning never).