### PR TITLE
share schema cache to reuse it

### DIFF
--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -5,6 +5,7 @@ require 'active_record_shards/configuration_parser'
 require 'active_record_shards/model'
 require 'active_record_shards/shard_selection'
 require 'active_record_shards/connection_switcher'
+require 'active_record_shards/connection_schema_cache'
 require 'active_record_shards/association_collection_connection_selection'
 require 'active_record_shards/migration'
 require 'active_record_shards/default_slave_patches'
@@ -21,6 +22,9 @@ end
 ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
 ActiveRecord::Base.extend(ActiveRecordShards::Model)
 ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
+class << ActiveRecord::Base
+  prepend ActiveRecordShards::ConnectionSchemaCache
+end
 ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
 ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
 ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)

--- a/lib/active_record_shards/connection_schema_cache.rb
+++ b/lib/active_record_shards/connection_schema_cache.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'active_record_shards/shard_support'
+
+# we share a single schema-cache across all connections, so columns etc queries get cached
+# this is safe as long as all connections have the same schema
+# also replaces the connection so we do not leave a possibly stale connection behind
+# TODO: make this the slave connections schema_cache for even more savings
+module ActiveRecordShards
+  module ConnectionSchemaCache
+    def connection
+      c = super
+      @schema_cache ||= c.schema_cache
+      @schema_cache.instance_variable_set(:@connection, c)
+      c.instance_variable_set(:@schema_cache, @schema_cache)
+      c
+    end
+  end
+end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -590,6 +590,18 @@ describe "connection switching" do
     end
   end
 
+  describe "schema cache" do
+    it "is shared between slave and master" do
+      slave = Ticket.on_slave { Ticket.connection.schema_cache.object_id }
+      Ticket.connection.schema_cache.object_id.must_equal slave
+    end
+
+    it "is shared between different models" do
+      slave = Email.on_slave { Email.connection.schema_cache.object_id }
+      Email.connection.schema_cache.object_id.must_equal slave
+    end
+  end
+
   if ActiveRecord::VERSION::MAJOR < 5
 
     it "raises an exception if a connection is not found" do


### PR DESCRIPTION
seeing slow queries to the master for read schema information which is silly

ideally we'd take the schema cache from the slave connection ... but that broke a lot of tests in strange ways ... so this might be a 90% solution (90% less work since for example with 10 shards we only do 1 master query instead of 10)

might want to pair on this further but for now I'm out of ideas ...

/cc @gabetax @bquorning @pschambacher 