### PR TITLE
make on_slave_by_default getter and setter behave consistently

### DIFF
--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -24,13 +24,11 @@ module ActiveRecordShards
     end
 
     def on_slave_by_default?
-      if self == ActiveRecord::Base
-        false
-      elsif self == base_class
-        on_slave_by_default
-      else
-        base_class.on_slave_by_default?
-      end
+      base_class.instance_variable_get(:@on_slave_by_default)
+    end
+
+    def on_slave_by_default=(value)
+      base_class.instance_variable_set(:@on_slave_by_default, value)
     end
 
     module InstanceMethods
@@ -53,11 +51,8 @@ module ActiveRecordShards
       base.after_initialize :initialize_shard_and_slave
     end
 
-    attr_writer :on_slave_by_default
-
     private
 
-    attr_reader :on_slave_by_default
     attr_accessor :sharded
   end
 end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -528,8 +528,18 @@ describe "connection switching" do
           assert_equal "master_name", model.name
         end
 
-        it "propogate the default_slave setting to inherited classes" do
+        it "propogate the on_slave_by_default reader to inherited classes" do
           assert AccountInherited.on_slave_by_default?
+        end
+
+        it "propogate the on_slave_by_default writer to inherited classes" do
+          begin
+            AccountInherited.on_slave_by_default = false
+            refute AccountInherited.on_slave_by_default?
+            refute Account.on_slave_by_default?
+          ensure
+            AccountInherited.on_slave_by_default = true
+          end
         end
 
         it "will :include things via has_and_belongs associations correctly" do


### PR DESCRIPTION
just saw this recursive calling foobar ... none of that is needed ... also was inconsistent since you could set on a inherited class and it would then read from the base class ...

FYI `ActiveRecord::Base.base_class == ActiveRecord::Base` so all works out

@pschambacher @bquorning 