### PR TITLE
Perform load_schema! on slave connection

### DIFF
--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -3,3 +3,4 @@ eval_gemfile 'gemfiles/common.rb'
 gem 'activerecord', '~> 3.2.19'
 gem 'mysql2', '~> 0.3.0'
 gem 'test-unit-minitest'
+

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -10,14 +10,11 @@ describe "connection switching" do
     end
   end
 
+  with_phenix
+
   before do
-    Phenix.rise!(with_schema: true)
     ActiveRecord::Base.establish_connection(RAILS_ENV.to_sym)
     require 'models'
-  end
-
-  after do
-    Phenix.burn!
   end
 
   describe "shard switching" do

--- a/test/migrator_test.rb
+++ b/test/migrator_test.rb
@@ -2,13 +2,7 @@
 require_relative 'helper'
 
 describe ActiveRecord::Migrator do
-  before do
-    Phenix.rise!(with_schema: true)
-  end
-
-  after do
-    Phenix.burn!
-  end
+  with_phenix
 
   it "migrates" do
     migration_path = File.join(File.dirname(__FILE__), "/migrations")

--- a/test/schema_dumper_extension_test.rb
+++ b/test/schema_dumper_extension_test.rb
@@ -5,18 +5,16 @@ if ActiveRecord::VERSION::MAJOR >= 4
   describe ActiveRecordShards::SchemaDumperExtension do
     describe "schema dump" do
       let(:schema_file) { Tempfile.new('active_record_shards_schema.rb') }
-      before do
-        Phenix.rise!(with_schema: true)
 
+      with_phenix
+
+      before do
         # create shard-specific columns
         ActiveRecord::Migrator.migrations_paths = [File.join(File.dirname(__FILE__), "/migrations")]
         ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths)
       end
 
-      after do
-        schema_file.unlink
-        Phenix.burn!
-      end
+      after { schema_file.unlink }
 
       it "includes the sharded tables" do
         ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, schema_file)


### PR DESCRIPTION
On Rails >= 5, the methods `.columns_hash`, `.columns`, `.attribute_types`, and `.column_defaults` all call `.load_schema!` via `.load_schema`. Instead of patching just `.columns`, we can make *all 4* methods work by just performing `.load_schema!` on the slave connection.

Needs tests…