### PR TITLE
patch mysql and not mysql-flexmaster

### DIFF
--- a/lib/active_record_shards/sql_comments.rb
+++ b/lib/active_record_shards/sql_comments.rb
@@ -10,7 +10,7 @@ module ActiveRecordShards
     end
 
     def self.enable
-      ActiveRecord::Base.connection.class.prepend(Methods)
+      ActiveRecord::Base.on_shard(nil) { ActiveRecord::Base.connection.class.prepend(Methods) }
     end
   end
 end


### PR DESCRIPTION
idk how to properly test this ... 
sharded connections are on MysqlFlexmasterAdapter which inherits from Mysql2Adapter ... so need to patch Mysql2Adapter ...

@pschambacher @bquorning 