### PR TITLE
Remove Email model

### DIFF
--- a/test/migrations/20110824010216_shard_migration.rb
+++ b/test/migrations/20110824010216_shard_migration.rb
@@ -3,10 +3,10 @@ class ShardMigration < BaseMigration
   shard :all
 
   def self.up
-    add_column :emails, :sharded_column, :integer
+    add_column :tickets, :sharded_column, :integer
   end
 
   def self.down
-    remove_column :emails, :sharded_column
+    remove_column :tickets, :sharded_column
   end
 end

--- a/test/migrator_test.rb
+++ b/test/migrator_test.rb
@@ -15,19 +15,19 @@ describe ActiveRecord::Migrator do
     end
 
     ActiveRecord::Base.on_all_shards do
-      assert table_has_column?("emails", "sharded_column")
+      assert table_has_column?("tickets", "sharded_column")
       assert !table_has_column?("accounts", "non_sharded_column")
     end
 
     ActiveRecord::Base.on_shard(nil) do
-      assert !table_has_column?("emails", "sharded_column")
+      assert !table_has_column?("tickets", "sharded_column")
       assert table_has_column?("accounts", "non_sharded_column")
     end
 
     # now test down/ up
     ActiveRecord::Migrator.run(:down, migration_path, 20110824010216)
     ActiveRecord::Base.on_all_shards do
-      assert !table_has_column?("emails", "sharded_column")
+      assert !table_has_column?("tickets", "sharded_column")
     end
 
     ActiveRecord::Migrator.run(:down, migration_path, 20110829215912)
@@ -37,7 +37,7 @@ describe ActiveRecord::Migrator do
 
     ActiveRecord::Migrator.run(:up, migration_path, 20110824010216)
     ActiveRecord::Base.on_all_shards do
-      assert table_has_column?("emails", "sharded_column")
+      assert table_has_column?("tickets", "sharded_column")
     end
 
     ActiveRecord::Migrator.run(:up, migration_path, 20110829215912)

--- a/test/models.rb
+++ b/test/models.rb
@@ -18,10 +18,6 @@ class AccountThing < ActiveRecord::Base
   end
 end
 
-class Email < ActiveRecord::Base
-  not_sharded
-end
-
 class AccountInherited < Account
 end
 

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -18,14 +18,6 @@ ActiveRecord::Schema.define(version: 1) do
     t.integer "person_id"
   end
 
-  create_table "emails", force: true do |t|
-    t.string   "from"
-    t.string   "to"
-    t.text     "mail"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "tickets", force: true do |t|
     t.string   "title"
     t.integer  "account_id"

--- a/test/schema_dumper_extension_test.rb
+++ b/test/schema_dumper_extension_test.rb
@@ -31,12 +31,12 @@ if ActiveRecord::VERSION::MAJOR >= 4
         end
 
         ActiveRecord::Base.on_all_shards do
-          assert table_has_column?("emails", "sharded_column")
+          assert table_has_column?("tickets", "sharded_column")
           assert !table_has_column?("accounts", "non_sharded_column")
         end
 
         ActiveRecord::Base.on_shard(nil) do
-          assert !table_has_column?("emails", "sharded_column")
+          assert !table_has_column?("tickets", "sharded_column")
           assert table_has_column?("accounts", "non_sharded_column")
         end
       end


### PR DESCRIPTION
The `Email` model was added in a8aca7d2c594e44f65906c897126886ce64d5cd2 to test “overriding connection of unsharded models”. That feature was removed again in 92c56232c51241f721b66530059cf51093f9168c, but the `Email` model remained.

Some time after its introduction `Email` was chosen for the tests of sharded migrations. This is concerning, since `Email` is an unsharded model... I have changed the migration tests to use the only sharded model, `Ticket`, instead.