### PR TITLE
Tests: Use separate schemas for sharded and unsharded

### DIFF
--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -643,10 +643,10 @@ describe "connection switching" do
       end
 
       it "work on association collections" do
-        begin
-          assert_using_master_db
-          account = Account.create!
+        assert_using_master_db
+        account = Account.create!
 
+        ActiveRecord::Base.on_shard(0) do
           account.tickets.create! title: 'master ticket'
 
           Ticket.on_slave do
@@ -655,11 +655,6 @@ describe "connection switching" do
 
           assert_equal "master ticket", account.tickets.first.title
           assert_equal "slave ticket", account.tickets.on_slave.first.title
-        rescue StandardError
-          retried ||= 0
-          retried += 1
-          puts "Failed in #{__LINE__}##{retried}"
-          retry if retried < 3
         end
       end
     end

--- a/test/migrator_test.rb
+++ b/test/migrator_test.rb
@@ -4,23 +4,27 @@ require_relative 'helper'
 describe ActiveRecord::Migrator do
   with_phenix
 
+  before { ActiveRecord::Base.establish_connection(RAILS_ENV.to_sym) }
+
   it "migrates" do
     migration_path = File.join(File.dirname(__FILE__), "/migrations")
+
+    refute ActiveRecord::Base.current_shard_id
     ActiveRecord::Migrator.migrate(migration_path)
+
     ActiveRecord::Base.on_all_shards do
       assert ActiveRecord::Base.connection.public_send(connection_exist_method, :schema_migrations), "Schema Migrations doesn't exist"
-      assert ActiveRecord::Base.connection.public_send(connection_exist_method, :accounts)
+      assert ActiveRecord::Base.connection.public_send(connection_exist_method, :tickets)
+      refute ActiveRecord::Base.connection.public_send(connection_exist_method, :accounts)
       assert ActiveRecord::Base.connection.select_value("select version from schema_migrations where version = '20110824010216'")
       assert ActiveRecord::Base.connection.select_value("select version from schema_migrations where version = '20110829215912'")
     end
 
     ActiveRecord::Base.on_all_shards do
       assert table_has_column?("tickets", "sharded_column")
-      assert !table_has_column?("accounts", "non_sharded_column")
     end
 
     ActiveRecord::Base.on_shard(nil) do
-      assert !table_has_column?("tickets", "sharded_column")
       assert table_has_column?("accounts", "non_sharded_column")
     end
 

--- a/test/schema_dumper_extension_test.rb
+++ b/test/schema_dumper_extension_test.rb
@@ -9,6 +9,8 @@ if ActiveRecord::VERSION::MAJOR >= 4
       with_phenix
 
       before do
+        ActiveRecord::Base.establish_connection(RAILS_ENV.to_sym)
+
         # create shard-specific columns
         ActiveRecord::Migrator.migrations_paths = [File.join(File.dirname(__FILE__), "/migrations")]
         ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths)
@@ -25,18 +27,15 @@ if ActiveRecord::VERSION::MAJOR >= 4
 
         ActiveRecord::Base.on_all_shards do
           assert ActiveRecord::Base.connection.public_send(connection_exist_method, :schema_migrations), "Schema Migrations doesn't exist"
-          assert ActiveRecord::Base.connection.public_send(connection_exist_method, :accounts)
           assert ActiveRecord::Base.connection.select_value("select version from schema_migrations where version = '20110824010216'")
           assert ActiveRecord::Base.connection.select_value("select version from schema_migrations where version = '20110829215912'")
         end
 
         ActiveRecord::Base.on_all_shards do
           assert table_has_column?("tickets", "sharded_column")
-          assert !table_has_column?("accounts", "non_sharded_column")
         end
 
         ActiveRecord::Base.on_shard(nil) do
-          assert !table_has_column?("tickets", "sharded_column")
           assert table_has_column?("accounts", "non_sharded_column")
         end
       end

--- a/test/sharded_schema.rb
+++ b/test/sharded_schema.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+ActiveRecord::Migration.verbose = false
+
+ActiveRecord::Schema.define(version: 1) do
+  create_table "tickets", force: true do |t|
+    t.string   "title"
+    t.integer  "account_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+end

--- a/test/unsharded_schema.rb
+++ b/test/unsharded_schema.rb
@@ -18,13 +18,6 @@ ActiveRecord::Schema.define(version: 1) do
     t.integer "person_id"
   end
 
-  create_table "tickets", force: true do |t|
-    t.string   "title"
-    t.integer  "account_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "people", force: true do |t|
     t.string "name"
     t.string "type"


### PR DESCRIPTION
Using the same schema for sharded and unsharded databases risks us having falsely positive tests.