### PR TITLE
Fixes for jacobat/hc-k8s branch

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -140,7 +140,13 @@ module ActiveRecordShards
       unless config = configurations[shard_env]
         raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config ? (configurations: #{configurations.inspect})"
       end
-      config[SHARD_NAMES_CONFIG_KEY] || raise("No shards configured for #{shard_env}")
+      unless config[SHARD_NAMES_CONFIG_KEY]
+        raise "No shards configured for #{shard_env}"
+      end
+      unless config[SHARD_NAMES_CONFIG_KEY].all? { |shard_name| shard_name.is_a?(Integer) }
+        raise "All shard names must be integers: #{config[SHARD_NAMES_CONFIG_KEY].inspect}."
+      end
+      config[SHARD_NAMES_CONFIG_KEY]
     end
 
     private

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -152,6 +152,12 @@ module ActiveRecordShards
         end
 
         if options.key?(:shard)
+          unless config = configurations[shard_env]
+            raise "Did not find #{shard_env} in configurations, did you forget to add it to your database.yml ? (configurations: #{configurations.inspect})"
+          end
+          unless shard = config['shard_names'].include?(options[:shard])
+            raise "Did not find shard #{options[:shard]} in configurations"
+          end
           current_shard_selection.shard = options[:shard]
         end
 

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -19,8 +19,7 @@ module ActiveRecordShards
     end
 
     def default_shard=(new_default_shard)
-      ActiveRecordShards::ShardSelection.default_shard = new_default_shard
-      switch_connection(shard: new_default_shard)
+      raise "default_shard= is deprecated"
     end
 
     def on_shard(shard)

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -129,7 +129,7 @@ module ActiveRecordShards
     end
 
     def current_shard_selection
-      Thread.current[:shard_selection] ||= ShardSelection.new
+      Thread.current[:shard_selection] ||= ShardSelection.new(shard_names.first)
     end
 
     def current_shard_id

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -138,7 +138,7 @@ module ActiveRecordShards
 
     def shard_names
       unless config = configurations[shard_env]
-        raise "Did not find #{shard_env} in configurations, did you forget to add it to your database.yml ? (configurations: #{configurations.inspect})"
+        raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config ? (configurations: #{configurations.inspect})"
       end
       config[SHARD_NAMES_CONFIG_KEY] || raise("No shards configured for #{shard_env}")
     end
@@ -149,7 +149,7 @@ module ActiveRecordShards
       if options.any?
         if options.key?(:shard)
           unless config = configurations[shard_env]
-            raise "Did not find #{shard_env} in configurations, did you forget to add it to your database.yml ? (configurations: #{configurations.inspect})"
+            raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config ? (configurations: #{configurations.inspect})"
           end
           unless shard = config['shard_names'].include?(options[:shard])
             raise "Did not find shard #{options[:shard]} in configurations"

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -140,7 +140,7 @@ module ActiveRecordShards
       unless config = configurations[shard_env]
         raise "Did not find #{shard_env} in configurations, did you forget to add it to your database.yml ? (configurations: #{configurations.inspect})"
       end
-      config[SHARD_NAMES_CONFIG_KEY] || []
+      config[SHARD_NAMES_CONFIG_KEY] || raise("No shards configured for #{shard_env}")
     end
 
     private

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -147,10 +147,6 @@ module ActiveRecordShards
 
     def switch_connection(options)
       if options.any?
-        if options.key?(:slave)
-          current_shard_selection.on_slave = options[:slave]
-        end
-
         if options.key?(:shard)
           unless config = configurations[shard_env]
             raise "Did not find #{shard_env} in configurations, did you forget to add it to your database.yml ? (configurations: #{configurations.inspect})"
@@ -159,6 +155,10 @@ module ActiveRecordShards
             raise "Did not find shard #{options[:shard]} in configurations"
           end
           current_shard_selection.shard = options[:shard]
+        end
+
+        if options.key?(:slave)
+          current_shard_selection.on_slave = options[:slave]
         end
 
         ensure_shard_connection

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -70,7 +70,7 @@ module ActiveRecordShards
     end
 
     def shard=(new_shard)
-      @shard = (new_shard || NO_SHARD)
+      @shard = Integer(new_shard)
     end
 
     def on_slave?

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 module ActiveRecordShards
   class ShardSelection
-    NO_SHARD = :_no_shard
-
     def initialize(shard)
       @on_slave = false
       self.shard = shard

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -9,12 +9,9 @@ module ActiveRecordShards
     if ActiveRecord::VERSION::MAJOR < 5
 
       def shard(klass = nil)
-        if (@shard || self.class.default_shard) && (klass.nil? || klass.is_sharded?)
-          if @shard == NO_SHARD
-            nil
-          else
-            @shard || self.class.default_shard
-          end
+        if klass.nil? || klass.is_sharded?
+          raise "Missing shard information on connection" unless @shard
+          @shard
         end
       end
 

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -38,11 +38,8 @@ module ActiveRecordShards
     else
 
       def shard
-        if @shard.nil? || @shard == NO_SHARD
-          nil
-        else
-          @shard || self.class.default_shard
-        end
+        raise "Missing shard information on connection" unless @shard
+        @shard
       end
 
       PRIMARY = "primary".freeze

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -2,7 +2,6 @@
 module ActiveRecordShards
   class ShardSelection
     NO_SHARD = :_no_shard
-    cattr_accessor :default_shard
 
     def initialize
       @on_slave = false

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -3,9 +3,9 @@ module ActiveRecordShards
   class ShardSelection
     NO_SHARD = :_no_shard
 
-    def initialize
+    def initialize(shard)
       @on_slave = false
-      @shard = nil
+      self.shard = shard
     end
 
     if ActiveRecord::VERSION::MAJOR < 5

--- a/test/configuration_parser_test.rb
+++ b/test/configuration_parser_test.rb
@@ -19,42 +19,42 @@ describe ActiveRecordShards::ConfigurationParser do
           "username"    => "root",
           "password"    => nil,
           "host"        => "main_slave_host",
-          "shard_names" => ["a", "b"].to_set
+          "shard_names" => [500, 501].to_set
         }, @conf)
       end
     end
 
     describe "shard a" do
       describe "master" do
-        before { @conf = @exploded_conf["test_shard_a"] }
+        before { @conf = @exploded_conf["test_shard_500"] }
         it "be exploded" do
           @conf["shard_names"] = @conf["shard_names"].to_set
           assert_equal({
             "adapter"     => "mysql",
             "encoding"    => "utf8",
-            "database"    => "ars_test_shard_a",
+            "database"    => "ars_test_shard_500",
             "port"        => 123,
             "username"    => "root",
             "password"    => nil,
-            "host"        => "shard_a_host",
-            "shard_names" => ["a", "b"].to_set
+            "host"        => "shard_500_host",
+            "shard_names" => [500, 501].to_set
           }, @conf)
         end
       end
 
       describe "slave" do
-        before { @conf = @exploded_conf["test_shard_a_slave"] }
+        before { @conf = @exploded_conf["test_shard_500_slave"] }
         it "be exploded" do
           @conf["shard_names"] = @conf["shard_names"].to_set
           assert_equal({
             "adapter"     => "mysql",
             "encoding"    => "utf8",
-            "database"    => "ars_test_shard_a",
+            "database"    => "ars_test_shard_500",
             "port"        => 123,
             "username"    => "root",
             "password"    => nil,
-            "host"        => "shard_a_slave_host",
-            "shard_names" => ["a", "b"].to_set
+            "host"        => "shard_500_slave_host",
+            "shard_names" => [500, 501].to_set
           }, @conf)
         end
       end
@@ -62,35 +62,35 @@ describe ActiveRecordShards::ConfigurationParser do
 
     describe "shard b" do
       describe "master" do
-        before { @conf = @exploded_conf["test_shard_b"] }
+        before { @conf = @exploded_conf["test_shard_501"] }
         it "be exploded" do
           @conf["shard_names"] = @conf["shard_names"].to_set
           assert_equal({
             "adapter"     => "mysql",
             "encoding"    => "utf8",
-            "database"    => "ars_test_shard_b",
+            "database"    => "ars_test_shard_501",
             "port"        => 123,
             "username"    => "root",
             "password"    => nil,
-            "host"        => "shard_b_host",
-            "shard_names" => ["a", "b"].to_set
+            "host"        => "shard_501_host",
+            "shard_names" => [500, 501].to_set
           }, @conf)
         end
       end
 
       describe "slave" do
-        before { @conf = @exploded_conf["test_shard_b_slave"] }
+        before { @conf = @exploded_conf["test_shard_501_slave"] }
         it "be exploded" do
           @conf["shard_names"] = @conf["shard_names"].to_set
           assert_equal({
             "adapter"     => "mysql",
             "encoding"    => "utf8",
-            "database"    => "ars_test_shard_b_slave",
+            "database"    => "ars_test_shard_501_slave",
             "port"        => 123,
             "username"    => "root",
             "password"    => nil,
-            "host"        => "shard_b_host",
-            "shard_names" => ["a", "b"].to_set
+            "host"        => "shard_501_host",
+            "shard_names" => [500, 501].to_set
           }, @conf)
         end
       end

--- a/test/database.yml
+++ b/test/database.yml
@@ -11,7 +11,7 @@ mysql: &MYSQL
 test:
   <<: *MYSQL
   database: ars_test
-  shard_names: ['0', '1']
+  shard_names: [0, 1]
 
 test_slave:
   <<: *MYSQL


### PR DESCRIPTION
The first commit should be squashed with dab057b8c5114b54c1384d253fd66b1cb6bde3cc. The 2nd commit is a consequence of 2c9bf0508aa08b724917d31adcf8357b069e2ee1 in which “we only allow integer names for shards.”