### PR TITLE
Don't let ActiveRecordShards::Model.sharded return nil

### DIFF
--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -11,12 +11,12 @@ module ActiveRecordShards
 
     def is_sharded? # rubocop:disable Naming/PredicateName
       if self == ActiveRecord::Base
-        sharded != false && supports_sharding?
+        sharded? && supports_sharding?
       elsif self == base_class
-        if sharded.nil?
+        if sharded?
           ActiveRecord::Base.is_sharded?
         else
-          sharded != false
+          sharded?
         end
       else
         base_class.is_sharded?
@@ -64,6 +64,14 @@ module ActiveRecordShards
 
     private
 
-    attr_accessor :sharded
+    attr_writer :sharded
+
+    def sharded?
+      if defined?(@sharded)
+        @sharded
+      else
+        @sharded = true
+      end
+    end
   end
 end

--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -10,17 +10,9 @@ module ActiveRecordShards
     end
 
     def is_sharded? # rubocop:disable Naming/PredicateName
-      if self == ActiveRecord::Base
-        sharded? && supports_sharding?
-      elsif self == base_class
-        if sharded?
-          ActiveRecord::Base.is_sharded?
-        else
-          sharded?
-        end
-      else
-        base_class.is_sharded?
-      end
+      base = (self == ActiveRecord::Base ? self : base_class)
+      value = base.sharded
+      value.nil? ? true : value
     end
 
     def on_slave_by_default?
@@ -62,16 +54,8 @@ module ActiveRecordShards
       base.after_initialize :initialize_shard_and_slave
     end
 
-    private
+    protected
 
-    attr_writer :sharded
-
-    def sharded?
-      if defined?(@sharded)
-        @sharded
-      else
-        @sharded = true
-      end
-    end
+    attr_accessor :sharded
   end
 end


### PR DESCRIPTION
Changing `ActiveRecordShards::Model.sharded` from a 3-state boolean to a 2-state boolean. This way we don’t need no nil-checks and `sharded != false`…