### PR TITLE
Test fewer rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 rvm:
-  - 2.2.4
-  - 2.3.3
-  - 2.4.0
+  - 2.4.2
 gemfile:
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
@@ -18,6 +16,6 @@ branches:
     - v4
 matrix:
   include:
-    - rvm: 2.4.0
+    - rvm: 2.4.2
       env:
         - TASK=rubocop


### PR DESCRIPTION
We can always add more Rubies back later, but while doing the v4 refactor work, we prefer to have a faster CI build time.