### PR TITLE
Remove useless test

### DIFF
--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -335,14 +335,6 @@ describe "connection switching" do
       assert_using_database('ars_test', Ticket)
     end
 
-    it "be able to find by column" do
-      Account.where(name: "peter").to_sql # does not blow up
-    end
-
-    it "have correct engine" do
-      assert_equal Account, Account.arel_engine
-    end
-
     describe "shard switching" do
       it "just stay on the main db" do
         assert_using_database('ars_test2', Ticket)


### PR DESCRIPTION
Corresponding code was removed in 689c76fec7df3b309e9612a5231bcb97edaa23c7, and `.arel_engine` is removed from Rails 5.2 in https://github.com/rails/rails/pull/29825