### PR TITLE
Soft deprecate

### DIFF
--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -3,10 +3,10 @@
 module ActiveRecordShards
   module Model
     def not_sharded
-      ActiveSupport::Deprecation.warn("Calling not_sharded is deprecated. "\
-                                      "Please ensure to still read from the "\
-                                      "account db slave after removing the "\
-                                      "call.")
+      ActiveRecord::Logger.warn("Calling not_sharded is deprecated. "\
+                                 "Please ensure to still read from the "\
+                                 "account db slave after removing the "\
+                                 "call.")
     end
 
     def is_sharded? # rubocop:disable Naming/PredicateName


### PR DESCRIPTION
ActiveSupport::Deprecation may potentially raise exception in applications
using this gem if Rails is configured to do so. This is very hard for users of
the gem to do anything about apart from not raising on deprecations. To avoid
this we'll revert to just logging deprecation notices for now. Once all
libraries using the not_sharded method have been upgraded we can fully
deprecate the method.