### PR TITLE
Simplify switch block

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -93,18 +93,18 @@ module ActiveRecordShards
       switch_connection(old_options) if old_options
     end
 
-    def on_cx_switch_block(which, force: false, construct_ro_scope: nil, &block)
+    def on_cx_switch_block(which, &block)
       @disallow_slave ||= 0
       @disallow_slave += 1 if which == :master
 
-      switch_to_slave = force || @disallow_slave.zero?
+      switch_to_slave = @disallow_slave.zero?
       old_options = current_shard_selection.options
 
       switch_connection(slave: switch_to_slave)
 
       # we avoid_readonly_scope to prevent some stack overflow problems, like when
       # .columns calls .with_scope which calls .columns and onward, endlessly.
-      if self == ActiveRecord::Base || !switch_to_slave || construct_ro_scope == false
+      if self == ActiveRecord::Base || !switch_to_slave
         yield
       else
         readonly.scoping(&block)

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -85,6 +85,14 @@ module ActiveRecordShards
       on_master_or_slave(:master, &block)
     end
 
+    def force_cx_switch_slave_block
+      old_options = current_shard_selection.options
+      switch_connection(slave: true)
+      yield
+    ensure
+      switch_connection(old_options) if old_options
+    end
+
     def on_cx_switch_block(which, force: false, construct_ro_scope: nil, &block)
       @disallow_slave ||= 0
       @disallow_slave += 1 if which == :master

--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -26,13 +26,13 @@ module ActiveRecordShards
     end
 
     def columns_with_force_slave(*args, &block)
-      on_cx_switch_block(:slave, construct_ro_scope: false, force: true) do
+      force_cx_switch_slave_block do
         columns_without_force_slave(*args, &block)
       end
     end
 
     def table_exists_with_force_slave?(*args, &block)
-      on_cx_switch_block(:slave, construct_ro_scope: false, force: true) do
+      force_cx_switch_slave_block do
         table_exists_without_force_slave?(*args, &block)
       end
     end


### PR DESCRIPTION
Break up the `on_cx_switch_block` method into 2 to capture the two use cases for it explicitly.