### PR TITLE
Break up sharding and master/slave handling

### DIFF
--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'active_record'
 require 'active_record/base'
+require 'active_record_shards/connection_resolver'
 require 'active_record_shards/configuration_parser'
 require 'active_record_shards/model'
 require 'active_record_shards/sharded_model'

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'active_record'
 require 'active_record/base'
+require 'active_record_shards/base_config'
 require 'active_record_shards/connection_resolver'
 require 'active_record_shards/configuration_parser'
 require 'active_record_shards/model'
@@ -19,6 +20,7 @@ module ActiveRecordShards
   end
 end
 
+ActiveRecord::Base.extend(ActiveRecordShards::BaseConfig)
 ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
 ActiveRecord::Base.extend(ActiveRecordShards::Model)
 ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -5,6 +5,7 @@ require 'active_record_shards/base_config'
 require 'active_record_shards/connection_resolver'
 require 'active_record_shards/configuration_parser'
 require 'active_record_shards/model'
+require 'active_record_shards/slave_db'
 require 'active_record_shards/sharded_model'
 require 'active_record_shards/shard_selection'
 require 'active_record_shards/connection_switcher'
@@ -24,6 +25,7 @@ ActiveRecord::Base.extend(ActiveRecordShards::BaseConfig)
 ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
 ActiveRecord::Base.extend(ActiveRecordShards::Model)
 ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
+ActiveRecord::Base.extend(ActiveRecordShards::SlaveDb)
 ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
 ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)
 ActiveRecord::Associations::CollectionProxy.include(ActiveRecordShards::AssociationCollectionConnectionSelection)

--- a/lib/active_record_shards/base_config.rb
+++ b/lib/active_record_shards/base_config.rb
@@ -3,5 +3,24 @@ module ActiveRecordShards
     def connection_config
       {}
     end
+
+    def connection_specification_name
+      name = connection_resolver.resolve_connection_name(connection_config)
+
+      unless configurations[name] || name == "primary"
+        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.inspect})"
+      end
+
+      name
+    end
+
+    def connection_resolver
+      Thread.current[:connection_resolver] ||=
+        ActiveRecordShards::ConnectionResolver.new(configurations)
+    end
+
+    def reset_connection_resolver
+      Thread.current[:connection_resolver] = nil
+    end
   end
 end

--- a/lib/active_record_shards/base_config.rb
+++ b/lib/active_record_shards/base_config.rb
@@ -1,0 +1,7 @@
+module ActiveRecordShards
+  module BaseConfig
+    def connection_config
+      {}
+    end
+  end
+end

--- a/lib/active_record_shards/connection_resolver.rb
+++ b/lib/active_record_shards/connection_resolver.rb
@@ -1,0 +1,31 @@
+module ActiveRecordShards
+  class ConnectionResolver
+    attr_reader :configurations
+
+    def initialize(configurations)
+      @configurations = configurations
+    end
+
+    PRIMARY = "primary".freeze
+    def resolve_connection_name(slave:, shard:, sharded:)
+      resolved_shard = sharded ? shard : nil
+
+      if !resolved_shard && !slave
+        return PRIMARY
+      end
+
+      @shard_names ||= {}
+      @shard_names[ActiveRecordShards.rails_env] ||= {}
+      @shard_names[ActiveRecordShards.rails_env][resolved_shard] ||= {}
+      @shard_names[ActiveRecordShards.rails_env][resolved_shard][slave] ||= begin
+        s = ActiveRecordShards.rails_env.dup
+        s << "_shard_#{resolved_shard}" if resolved_shard
+
+        if slave && configurations["#{s}_slave"] # fall back to master connection
+          s << "_slave"
+        end
+        s
+      end
+    end
+  end
+end

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -44,27 +44,8 @@ module ActiveRecordShards
       switch_connection(old_options)
     end
 
-    def connection_specification_name
-      name = connection_resolver.resolve_connection_name(connection_config)
-
-      unless configurations[name] || name == "primary"
-        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.inspect})"
-      end
-
-      name
-    end
-
     def connection_config
       super.merge(current_shard_selection.options.merge(sharded: is_sharded?))
-    end
-
-    def connection_resolver
-      Thread.current[:connection_resolver] ||=
-        ActiveRecordShards::ConnectionResolver.new(configurations)
-    end
-
-    def reset_connection_resolver
-      Thread.current[:connection_resolver] = nil
     end
 
     def supports_sharding?

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -115,13 +115,17 @@ module ActiveRecordShards
     end
 
     def connection_specification_name
-      name = connection_resolver.resolve_connection_name(current_shard_selection.options.merge(sharded: is_sharded?))
+      name = connection_resolver.resolve_connection_name(connection_config)
 
       unless configurations[name] || name == "primary"
         raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.inspect})"
       end
 
       name
+    end
+
+    def connection_config
+      current_shard_selection.options.merge(sharded: is_sharded?)
     end
 
     def connection_resolver

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -125,7 +125,7 @@ module ActiveRecordShards
     end
 
     def connection_config
-      current_shard_selection.options.merge(sharded: is_sharded?)
+      super.merge(current_shard_selection.options.merge(sharded: is_sharded?))
     end
 
     def connection_resolver

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -107,7 +107,7 @@ module ActiveRecordShards
         end
 
         if options.key?(:slave)
-          current_shard_selection.on_slave = options[:slave]
+          self.current_slave_selection = options[:slave]
         end
 
         ensure_shard_connection

--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -39,7 +39,7 @@ module ActiveRecordShards
 
     module InstanceMethods
       def initialize_shard_and_slave
-        @from_slave = !!self.class.current_shard_selection.options[:slave]
+        @from_slave = !!self.class.current_slave_selection
         @from_shard = self.class.current_shard_selection.options[:shard]
       end
 

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -11,28 +11,6 @@ module ActiveRecordShards
       @shard
     end
 
-    PRIMARY = "primary".freeze
-    def resolve_connection_name(sharded:, configurations:)
-      resolved_shard = sharded ? shard : nil
-
-      if !resolved_shard && !@on_slave
-        return PRIMARY
-      end
-
-      @shard_names ||= {}
-      @shard_names[ActiveRecordShards.rails_env] ||= {}
-      @shard_names[ActiveRecordShards.rails_env][resolved_shard] ||= {}
-      @shard_names[ActiveRecordShards.rails_env][resolved_shard][@on_slave] ||= begin
-        s = ActiveRecordShards.rails_env.dup
-        s << "_shard_#{resolved_shard}" if resolved_shard
-
-        if @on_slave && configurations["#{s}_slave"] # fall back to master connection
-          s << "_slave"
-        end
-        s
-      end
-    end
-
     def shard=(new_shard)
       @shard = Integer(new_shard)
     end

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -2,7 +2,6 @@
 module ActiveRecordShards
   class ShardSelection
     def initialize(shard)
-      @on_slave = false
       self.shard = shard
     end
 
@@ -15,16 +14,8 @@ module ActiveRecordShards
       @shard = Integer(new_shard)
     end
 
-    def on_slave?
-      @on_slave
-    end
-
-    def on_slave=(new_slave)
-      @on_slave = (new_slave == true)
-    end
-
     def options
-      { shard: @shard, slave: @on_slave }
+      { shard: @shard }
     end
   end
 end

--- a/lib/active_record_shards/slave_db.rb
+++ b/lib/active_record_shards/slave_db.rb
@@ -1,0 +1,96 @@
+module ActiveRecordShards
+  module SlaveDb
+    def on_slave_if(condition, &block)
+      condition ? on_slave(&block) : yield
+    end
+
+    def on_slave_unless(condition, &block)
+      on_slave_if(!condition, &block)
+    end
+
+    def on_master_if(condition, &block)
+      condition ? on_master(&block) : yield
+    end
+
+    def on_master_unless(condition, &block)
+      on_master_if(!condition, &block)
+    end
+
+    def on_master_or_slave(which, &block)
+      if block_given?
+        on_cx_switch_block(which, &block)
+      else
+        MasterSlaveProxy.new(self, which)
+      end
+    end
+
+    def on_slave?
+      current_slave_selection
+    end
+
+    # Executes queries using the slave database. Fails over to master if no slave is found.
+    # if you want to execute a block of code on the slave you can go:
+    #   Account.on_slave do
+    #     Account.first
+    #   end
+    # the first account will be found on the slave DB
+    #
+    # For one-liners you can simply do
+    #   Account.on_slave.first
+    def on_slave(&block)
+      on_master_or_slave(:slave, &block)
+    end
+
+    def on_master(&block)
+      on_master_or_slave(:master, &block)
+    end
+
+    def force_cx_switch_slave_block
+      old_options = current_shard_selection.options
+      switch_connection(slave: true)
+      yield
+    ensure
+      switch_connection(old_options) if old_options
+    end
+
+    def on_cx_switch_block(which, &block)
+      @disallow_slave ||= 0
+      @disallow_slave += 1 if which == :master
+
+      switch_to_slave = @disallow_slave.zero?
+      old_options = current_shard_selection.options
+
+      switch_connection(slave: switch_to_slave)
+
+      # we avoid_readonly_scope to prevent some stack overflow problems, like when
+      # .columns calls .with_scope which calls .columns and onward, endlessly.
+      if self == ActiveRecord::Base || !switch_to_slave
+        yield
+      else
+        readonly.scoping(&block)
+      end
+    ensure
+      @disallow_slave -= 1 if which == :master
+      switch_connection(old_options) if old_options
+    end
+
+    def current_slave_selection=(on_slave)
+      Thread.current[:slave_selection] = on_slave
+    end
+
+    def current_slave_selection
+      Thread.current[:slave_selection] ||= true
+    end
+
+    class MasterSlaveProxy
+      def initialize(target, which)
+        @target = target
+        @which = which
+      end
+
+      def method_missing(method, *args, &block) # rubocop:disable Style/MethodMissing
+        @target.on_master_or_slave(@which) { @target.send(method, *args, &block) }
+      end
+    end
+  end
+end

--- a/lib/active_record_shards/sql_comments.rb
+++ b/lib/active_record_shards/sql_comments.rb
@@ -3,7 +3,7 @@ module ActiveRecordShards
   module SqlComments
     module Methods
       def execute(query, name = nil)
-        slave = ActiveRecord::Base.current_shard_selection.on_slave?
+        slave = ActiveRecord::Base.current_slave_selection
         query += " /* #{slave ? 'slave' : 'master'} */"
         super(query, name)
       end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -245,12 +245,14 @@ describe "connection switching" do
       before do
         @saved_config = ActiveRecord::Base.configurations.delete('test_slave')
         Thread.current[:shard_selection] = nil # drop caches
+        ActiveRecord::Base.reset_connection_resolver
         ActiveRecord::Base.connection_handler.connection_pool_list.clear
         ActiveRecord::Base.establish_connection(:test)
       end
 
       after do
         ActiveRecord::Base.configurations['test_slave'] = @saved_config
+        ActiveRecord::Base.reset_connection_resolver
         Thread.current[:shard_selection] = nil # drop caches
       end
 

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -23,7 +23,7 @@ describe "connection switching" do
     end
 
     it "does not fail on unrelated ensure error when current_shard_selection fails" do
-      ActiveRecord::Base.expects(:current_shard_selection).raises(ArgumentError)
+      ActiveRecord::Base.expects(:current_shard_selection).at_least_once.raises(ArgumentError)
       assert_raises ArgumentError do
         ActiveRecord::Base.on_slave { 1 }
       end


### PR DESCRIPTION
The intent of this is to split master/slave logic from sharding logic allowing either to be understood more easily.

We introduce a BaseConfig module which must be included before the sharding (ConnectionSwitching) and master/slave (SlaveDb) modules. This ensures that the `connection_config` method will work if either module is missing and regardless of the order in which the latter two modules are included.

