### PR TITLE
Ensure boolean value returned without memoization

### DIFF
--- a/lib/active_record_shards/slave_db.rb
+++ b/lib/active_record_shards/slave_db.rb
@@ -79,7 +79,7 @@ module ActiveRecordShards
     end
 
     def current_slave_selection
-      Thread.current[:slave_selection] ||= false
+      !!Thread.current[:slave_selection]
     end
 
     def connection_config


### PR DESCRIPTION
The memoization here doesn't work for false.