### PR TITLE
Add on_shard? predicate

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -64,6 +64,10 @@ module ActiveRecordShards
       current_shard_selection.shard
     end
 
+    def on_shard?
+      current_shard_selection.on_shard?
+    end
+
     def shard_names
       unless config = configurations[shard_env]
         raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.inspect})"

--- a/lib/active_record_shards/no_shard_selection.rb
+++ b/lib/active_record_shards/no_shard_selection.rb
@@ -10,5 +10,9 @@ module ActiveRecordShards
     def connection_config
       raise NoShardSelected, "No shard selected, can't connect"
     end
+
+    def on_shard?
+      false
+    end
   end
 end

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -10,5 +10,9 @@ module ActiveRecordShards
     def connection_config
       { shard: shard }
     end
+
+    def on_shard?
+      true
+    end
   end
 end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -10,6 +10,16 @@ describe "connection switching" do
   end
 
   describe "shard switching" do
+    it "is not on_shard? when no shard is selected" do
+      refute ActiveRecordShards::ShardedModel.on_shard?
+    end
+
+    it "is on_shard? when shard is selected" do
+      ActiveRecordShards::ShardedModel.on_first_shard do
+        assert ActiveRecordShards::ShardedModel.on_shard?
+      end
+    end
+
     it "raises when retrieving connection spec name without being connected to a shard" do
       Ticket.on_shard(0) { Ticket.connection_specification_name }
       assert_raises ActiveRecordShards::NoShardSelection::NoShardSelected do


### PR DESCRIPTION
Today users are checking if current_shard_id is nil. This is no longer possible
as current_shard_id will now return an exception in case no shard has been
selected. Instead users can now use the on_shard? method to figure out if a
shard is currently selected.