### PR TITLE
Remove leftovers

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -118,17 +118,6 @@ module ActiveRecordShards
     def load_schema_with_default_shard!
       with_default_shard { load_schema_without_default_shard! }
     end
-
-    class MasterSlaveProxy
-      def initialize(target, which)
-        @target = target
-        @which = which
-      end
-
-      def method_missing(method, *args, &block) # rubocop:disable Style/MethodMissing
-        @target.on_master_or_slave(@which) { @target.send(method, *args, &block) }
-      end
-    end
   end
 end
 


### PR DESCRIPTION
MasterSlaveProxy was *copied* in 526a463b645050e5327062147d937bbacf3ef5a3, but should have been *moved* instead.