### PR TITLE
Split slave scope by sharding

### DIFF
--- a/lib/active_record_shards/base_config.rb
+++ b/lib/active_record_shards/base_config.rb
@@ -4,6 +4,10 @@ module ActiveRecordShards
       { shard: nil, sharded: false }
     end
 
+    def slave_thread_variable_name
+      :unsharded_slave_selection
+    end
+
     def connection_specification_name
       name = connection_resolver.resolve_connection_name(connection_config)
 

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -21,6 +21,10 @@ module ActiveRecordShards
       switch_connection(old_selection)
     end
 
+    def slave_thread_variable_name
+      :sharded_slave_selection
+    end
+
     def on_first_shard
       shard_name = shard_names.first
       on_shard(shard_name) { yield }

--- a/lib/active_record_shards/slave_db.rb
+++ b/lib/active_record_shards/slave_db.rb
@@ -75,11 +75,11 @@ module ActiveRecordShards
     end
 
     def current_slave_selection=(on_slave)
-      Thread.current[:slave_selection] = on_slave
+      Thread.current[slave_thread_variable_name] = on_slave
     end
 
     def current_slave_selection
-      !!Thread.current[:slave_selection]
+      !!Thread.current[slave_thread_variable_name]
     end
 
     def connection_config

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -10,6 +10,19 @@ describe "connection switching" do
   end
 
   describe "shard switching" do
+    it "can use sharded master database" do
+      ActiveRecord::Base.connection_handler.connection_pool_list.clear
+      # Connect to a shard
+      ActiveRecordShards::ShardedModel.on_shard(0) do
+        ticket = Ticket.create(title: "On master")
+        # Connect to the unsharded slave database
+        ActiveRecord::Base.on_slave do
+          # Retrieve from the sharded master database
+          assert Ticket.exists?(ticket.id)
+        end
+      end
+    end
+
     it "is not on_shard? when no shard is selected" do
       refute ActiveRecordShards::ShardedModel.on_shard?
     end


### PR DESCRIPTION
When calling ActiveRecord::Base.on_slave it will now only apply to unsharded
connections. To use slave dbs for sharded connections one must use the
ActiveRecordShards::ShardedModel.on_slave method now.

This fixes an issue where the connection to the sharded slave database would
not be established - yet would attempted to be used - when calling

```
ActiveRecordShards::ShardedModel(shard) {
  ActiveRecord::Base.on_slave { ... }
}
```