### PR TITLE
Remove call to on_shard directly on ActiveRecord::Base

### DIFF
--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -51,8 +51,7 @@ namespace :db do
   desc "Raises an error if there are pending migrations"
   task abort_if_pending_migrations: :environment do
     if defined? ActiveRecord
-      pending_migrations =
-        ActiveRecord::Base.on_shard(nil) { ActiveRecord::Migrator.open(ActiveRecord::Migrator.migrations_paths).pending_migrations }
+      pending_migrations = ActiveRecord::Migrator.open(ActiveRecord::Migrator.migrations_paths).pending_migrations
 
       if pending_migrations.any?
         puts "You have #{pending_migrations.size} pending migrations:"


### PR DESCRIPTION
I think this call was missed when moving the `on_shard` method out of AR::Base and making the default not_sharded.

/cc @bquorning @grosser @jacobat 