### PR TITLE
Compatibility with Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 rvm:
-  - 2.1.10
-  - 2.2.4
-  - 2.3.3
-  - 2.4.0
+  - 2.2
+  - 2.3
+  - 2.4
 gemfile:
   - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
+  - gemfiles/rails5.2.gemfile
 bundler_args: --no-deployment
 script: bundle exec rake $TASK
 env:
@@ -22,13 +22,9 @@ branches:
     - 3-7-0
 matrix:
   exclude:
-    - rvm: 2.4.0
+    - rvm: 2.4
       gemfile: gemfiles/rails3.2.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails5.0.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails5.1.gemfile
   include:
-    - rvm: 2.4.0
+    - rvm: 2.4
       env:
         - TASK=rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ task default: ["rubocop", "wwtd:local"]
 
 RuboCop::RakeTask.new
 
+desc 'Run an IRB console with ActiveRecordShards loaded'
 task :console do
   require 'irb'
   require 'irb/completion'

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,6 +1,5 @@
-eval_gemfile 'gemfiles/common.rb'
+eval_gemfile 'common.rb'
 
 gem 'activerecord', '~> 3.2.19'
 gem 'mysql2', '~> 0.3.0'
 gem 'test-unit-minitest'
-

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile 'gemfiles/common.rb'
+eval_gemfile 'common.rb'
 
 gem 'activerecord', '~> 4.2.0'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile 'gemfiles/common.rb'
+eval_gemfile 'common.rb'
 
 gem 'activerecord', '~> 5.0.0'

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile 'gemfiles/common.rb'
+eval_gemfile 'common.rb'
 
 gem 'activerecord', '~> 5.1.3'

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile 'common.rb'
+
+gem 'activerecord', '~> 5.2.0.beta2'

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -30,7 +30,7 @@ when '3.2'
   require 'active_record_shards/patches-3-2'
 when '4.2'
   require 'active_record_shards/patches-4-2'
-when '5.0', '5.1'
+when '5.0', '5.1', '5.2'
   require 'active_record_shards/patches-5-0'
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -220,7 +220,7 @@ when '3.2', '4.2'
   require 'active_record_shards/connection_switcher-4-0'
 when '5.0'
   require 'active_record_shards/connection_switcher-5-0'
-when '5.1'
+when '5.1', '5.2'
   require 'active_record_shards/connection_switcher-5-1'
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -5,6 +5,9 @@ require_relative 'helper'
 # ActiveRecord needs to be loaded first.
 Rake::Application.new.rake_require("active_record/railties/databases")
 require 'active_record_shards/tasks'
+task :environment do
+  # Only required as a dependency
+end
 
 describe "Database rake tasks" do
   def capture_stderr


### PR DESCRIPTION
/cc @grosser @bquorning 

Not pretty but it fixes a rake task test in 5.2 (`drop` requiring `environment`)
It's only for v3 anyway.