### PR TITLE
Lock down mysql2 versions

### DIFF
--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,3 +1,4 @@
 eval_gemfile 'common.rb'
 
 gem 'activerecord', '~> 4.2.0'
+gem 'mysql2', '>= 0.3.13', '< 0.5'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,3 +1,4 @@
 eval_gemfile 'common.rb'
 
 gem 'activerecord', '~> 5.0.0'
+gem 'mysql2', '>= 0.3.18', '< 0.5'

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,3 +1,4 @@
 eval_gemfile 'common.rb'
 
 gem 'activerecord', '~> 5.1.3'
+gem 'mysql2', '>= 0.3.18', '< 0.5'

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,3 +1,4 @@
 eval_gemfile 'common.rb'
 
-gem 'activerecord', '~> 5.2.0.beta2'
+gem 'activerecord', '5.2.0.beta2'
+gem 'mysql2', '~> 0.4.4'


### PR DESCRIPTION
Since mysql2 version 0.5 was released, we need to lock down the mysql2 version that matches each corresponding Rails version.

See e.g. https://github.com/rails/rails/blob/v5.1.0/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L4