### PR TITLE
Remove DB configuration inspection

### DIFF
--- a/lib/active_record_shards/connection_switcher-4-0.rb
+++ b/lib/active_record_shards/connection_switcher-4-0.rb
@@ -22,7 +22,7 @@ module ActiveRecordShards
       spec = configurations[name]
 
       if spec.nil?
-        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.inspect})"
+        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.keys.inspect})"
       end
 
       # in 3.2 rails is asking for a connection pool in a map of these ConnectionSpecifications.  If we want to re-use connections,

--- a/lib/active_record_shards/connection_switcher-5-0.rb
+++ b/lib/active_record_shards/connection_switcher-5-0.rb
@@ -4,7 +4,7 @@ module ActiveRecordShards
       name = current_shard_selection.resolve_connection_name(sharded: is_sharded?, configurations: configurations)
 
       unless configurations[name] || name == "primary"
-        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.inspect})"
+        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.keys.inspect})"
       end
 
       name

--- a/lib/active_record_shards/connection_switcher-5-1.rb
+++ b/lib/active_record_shards/connection_switcher-5-1.rb
@@ -4,7 +4,7 @@ module ActiveRecordShards
       name = current_shard_selection.resolve_connection_name(sharded: is_sharded?, configurations: configurations)
 
       unless configurations[name] || name == "primary"
-        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.inspect})"
+        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.keys.inspect})"
       end
 
       name


### PR DESCRIPTION
Previously, if the `ActiveRecord::AdapterNotSpecified` exception was raised, the whole configurations object would be inspected - including information like shard sets and credentials for accessing the mysql cluster.

This PR fixes the above by only inspecting the keys inside the configurations hash.

@bquorning @pschambacher please review