### PR TITLE
Add information on current gem maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bquorning

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new "active_record_shards", "3.12.0.beta1" do |s|
-  s.authors     = ["Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
-  s.email       = ["mick@staugaard.com", "eac@zendesk.com", "ben@gimbo.net"]
+  s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
+  s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"
   s.summary     = "Simple database switching for ActiveRecord."
   s.description = "Easily run queries on shard and slave databases."


### PR DESCRIPTION
Adds current maintainers to gemspec, but keep names of previous contributors.