### PR TITLE
Reuse primary DB connection when main DB configuration has no slave

### DIFF
--- a/test/database.yml
+++ b/test/database.yml
@@ -40,3 +40,13 @@ test2:
 test2_slave:
   <<: *MYSQL
   database: ars_test2_slave
+
+test3:
+  <<: *MYSQL
+  database: ars_test3
+  shard_names: [0]
+
+test3_shard_0:
+  <<: *MYSQL
+  database: ars_test3_shard0
+

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -102,6 +102,18 @@ Minitest::Spec.class_eval do
     end
   end
 
+  def self.switch_rails_env(env)
+    before do
+      silence_warnings { Object.const_set("RAILS_ENV", env) }
+      ActiveRecord::Base.establish_connection(::RAILS_ENV.to_sym)
+    end
+    after do
+      silence_warnings { Object.const_set("RAILS_ENV", 'test') }
+      ActiveRecord::Base.establish_connection(::RAILS_ENV.to_sym)
+      assert_using_database('ars_test', Ticket)
+    end
+  end
+
   # create all databases and then tear them down after test
   # avoid doing any shard switching while preparing our databases
   def self.with_phenix


### PR DESCRIPTION
ActiveRecord always names its default connection pool 'primary'
while everything else is named by the configuration name.

You got it right when the main DB has a slave config but the case when it doesn't wasn't handled correctly. That is why the additional connection pool is made with the name `Rails.env` while "primary" should be used instead.

A better way to write a test for that is welcome.
