### PR TITLE
Tuning of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,23 +49,9 @@ jobs:
     <<: *test
 
   # Rails 5.0
-  ruby-2.2-rails-5.0-test:
+  ruby-2.5-rails-5.0-test:
     docker:
-      - image: circleci/ruby:2.2
-      - image: circleci/mysql:5.7-ram
-    environment:
-      - BUNDLE_GEMFILE: gemfiles/rails5.0.gemfile
-    <<: *test
-  ruby-2.3-rails-5.0-test:
-    docker:
-      - image: circleci/ruby:2.3
-      - image: circleci/mysql:5.7-ram
-    environment:
-      - BUNDLE_GEMFILE: gemfiles/rails5.0.gemfile
-    <<: *test
-  ruby-2.4-rails-5.0-test:
-    docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.5
       - image: circleci/mysql:5.7-ram
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails5.0.gemfile
@@ -153,9 +139,7 @@ workflows:
       - ruby-2.4-rails-4.2-test
       - ruby-2.5-rails-4.2-test
 
-      - ruby-2.2-rails-5.0-test
-      - ruby-2.3-rails-5.0-test
-      - ruby-2.4-rails-5.0-test
+      - ruby-2.5-rails-5.0-test
 
       - ruby-2.2-rails-5.1-test
       - ruby-2.3-rails-5.1-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,13 @@ jobs:
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
     <<: *test
+  ruby-2.5-rails-4.2-test:
+    docker:
+      - image: circleci/ruby:2.5
+      - image: circleci/mysql:5.7-ram
+    environment:
+      - BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
+    <<: *test
 
   # Rails 5.0
   ruby-2.2-rails-5.0-test:
@@ -93,6 +100,13 @@ jobs:
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
     <<: *test
+  ruby-2.5-rails-5.1-test:
+    docker:
+      - image: circleci/ruby:2.5
+      - image: circleci/mysql:5.7-ram
+    environment:
+      - BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
+    <<: *test
 
   # Rails 5.2
   ruby-2.2-rails-5.2-test:
@@ -116,11 +130,18 @@ jobs:
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
     <<: *test
+  ruby-2.5-rails-5.2-test:
+    docker:
+      - image: circleci/ruby:2.5
+      - image: circleci/mysql:5.7-ram
+    environment:
+      - BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
+    <<: *test
 
   # Rubocop
   rubocop:
     docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.5
     steps:
       - checkout
       - run: bundle install
@@ -138,6 +159,7 @@ workflows:
       - ruby-2.2-rails-4.2-test
       - ruby-2.3-rails-4.2-test
       - ruby-2.4-rails-4.2-test
+      - ruby-2.5-rails-4.2-test
 
       - ruby-2.2-rails-5.0-test
       - ruby-2.3-rails-5.0-test
@@ -146,7 +168,9 @@ workflows:
       - ruby-2.2-rails-5.1-test
       - ruby-2.3-rails-5.1-test
       - ruby-2.4-rails-5.1-test
+      - ruby-2.5-rails-5.1-test
 
       - ruby-2.2-rails-5.2-test
       - ruby-2.3-rails-5.2-test
       - ruby-2.4-rails-5.2-test
+      - ruby-2.5-rails-5.2-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,6 @@ jobs:
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails3.2.gemfile
     <<: *test
-  ruby-2.3-rails-3.2-test:
-    docker:
-      - image: circleci/ruby:2.3
-      - image: circleci/mysql:5.6-ram # Not compatible with MySQL 5.7
-    environment:
-      - BUNDLE_GEMFILE: gemfiles/rails3.2.gemfile
-    <<: *test
 
   # Rails 4.2
   ruby-2.2-rails-4.2-test:
@@ -154,7 +147,6 @@ workflows:
       - rubocop
 
       - ruby-2.2-rails-3.2-test
-      - ruby-2.3-rails-3.2-test
 
       - ruby-2.2-rails-4.2-test
       - ruby-2.3-rails-4.2-test


### PR DESCRIPTION
Test also with Ruby 2.5.
We should deprecate Ruby 2.2, Rails 3.2 and Rails 5.0 support soon, but I know of someone still using both Ruby 2.2 and Rails 3.2 so we’ll wait a bit on pulling the plug completely.