### PR TITLE
Add the ability to make all models not sharded by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,2 @@
-eval_gemfile 'gemfiles/rails5.2.gemfile'
+version = ENV['RAILS_VERSION'] || '5.2'
+eval_gemfile "gemfiles/rails#{version}.gemfile"

--- a/README.md
+++ b/README.md
@@ -99,11 +99,18 @@ end
 ## Usage
 
 Normally you have some models that live on a shared database, and you might need to query this data in order to know what shard to switch to.
-All the models that live on the shared database must be marked as not\_sharded:
+All models are considered sharded by default, but it can be changed with:
+
+``` ruby
+ActiveRecord::Base.sharded = false
+```
+
+Individual models can override this setting.
+All the models that live on the shared database must be marked as not sharded:
 
 ```ruby
 class Account < ActiveRecord::Base
-  not_sharded
+  self.sharded = false
 
   has_many :projects
 end

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -19,7 +19,7 @@ module ActiveRecordShards
 end
 
 ActiveRecord::Base.extend(ActiveRecordShards::ConfigurationParser)
-ActiveRecord::Base.extend(ActiveRecordShards::Model)
+ActiveRecord::Base.include(ActiveRecordShards::Model)
 ActiveRecord::Base.extend(ActiveRecordShards::ConnectionSwitcher)
 ActiveRecord::Base.extend(ActiveRecordShards::DefaultSlavePatches)
 ActiveRecord::Relation.include(ActiveRecordShards::DefaultSlavePatches::ActiveRelationPatches)

--- a/lib/active_record_shards/connection_switcher-5-0.rb
+++ b/lib/active_record_shards/connection_switcher-5-0.rb
@@ -16,7 +16,7 @@ module ActiveRecordShards
       # See if we've connected before. If not, call `#establish_connection`
       # so that ActiveRecord can resolve connection_specification_name to an
       # ARS connection.
-      spec_name = connection_specification_name
+      spec_name = current_shard_selection.resolve_connection_name(sharded: true, configurations: configurations)
 
       pool = connection_handler.retrieve_connection_pool(spec_name)
       if pool.nil?

--- a/lib/active_record_shards/connection_switcher-5-1.rb
+++ b/lib/active_record_shards/connection_switcher-5-1.rb
@@ -16,7 +16,7 @@ module ActiveRecordShards
       # See if we've connected before. If not, call `#establish_connection`
       # so that ActiveRecord can resolve connection_specification_name to an
       # ARS connection.
-      spec_name = connection_specification_name
+      spec_name = current_shard_selection.resolve_connection_name(sharded: true, configurations: configurations)
 
       pool = connection_handler.retrieve_connection_pool(spec_name)
       connection_handler.establish_connection(spec_name.to_sym) if pool.nil?

--- a/lib/active_record_shards/model.rb
+++ b/lib/active_record_shards/model.rb
@@ -2,68 +2,60 @@
 
 module ActiveRecordShards
   module Model
-    def not_sharded
-      if self != ActiveRecord::Base && self != base_class
-        raise "You should only call not_sharded on direct descendants of ActiveRecord::Base"
+    module ClassMethods
+      def not_sharded
+        self.sharded = false
       end
-      self.sharded = false
-    end
 
-    def is_sharded? # rubocop:disable Naming/PredicateName
-      if self == ActiveRecord::Base
-        sharded != false && supports_sharding?
-      elsif self == base_class
-        if sharded.nil?
-          ActiveRecord::Base.is_sharded?
+      def sharded=(value)
+        if self != ActiveRecord::Base && self != base_class
+          raise ArgumentError, "You should only set sharded on base or abstract classes"
+        end
+        super(value)
+      end
+
+      def is_sharded? # rubocop:disable Naming/PredicateName
+        sharded
+      end
+
+      def on_slave_by_default?
+        if self == ActiveRecord::Base
+          false
         else
-          sharded != false
+          base = base_class
+          if base.instance_variable_defined?(:@on_slave_by_default)
+            base.instance_variable_get(:@on_slave_by_default)
+          end
         end
-      else
-        base_class.is_sharded?
       end
-    end
 
-    def on_slave_by_default?
-      if self == ActiveRecord::Base
-        false
-      else
-        base = base_class
-        if base.instance_variable_defined?(:@on_slave_by_default)
-          base.instance_variable_get(:@on_slave_by_default)
+      def on_slave_by_default=(value)
+        if self == ActiveRecord::Base
+          raise ArgumentError, "Cannot set on_slave_by_default on ActiveRecord::Base"
+        else
+          base_class.instance_variable_set(:@on_slave_by_default, value)
         end
       end
     end
 
-    def on_slave_by_default=(value)
-      if self == ActiveRecord::Base
-        raise ArgumentError, "Cannot set on_slave_by_default on ActiveRecord::Base"
-      else
-        base_class.instance_variable_set(:@on_slave_by_default, value)
-      end
+    def initialize_shard_and_slave
+      @from_slave = !!self.class.current_shard_selection.options[:slave]
+      @from_shard = self.class.current_shard_selection.options[:shard]
     end
 
-    module InstanceMethods
-      def initialize_shard_and_slave
-        @from_slave = !!self.class.current_shard_selection.options[:slave]
-        @from_shard = self.class.current_shard_selection.options[:shard]
-      end
-
-      def from_slave?
-        @from_slave
-      end
-
-      def from_shard
-        @from_shard
-      end
+    def from_slave?
+      @from_slave
     end
 
-    def self.extended(base)
-      base.send(:include, InstanceMethods)
+    def from_shard
+      @from_shard
+    end
+
+    def self.included(base)
+      base.class_attribute :sharded, instance_accessor: false, instance_predicate: false
+      base.singleton_class.prepend(ClassMethods)
       base.after_initialize :initialize_shard_and_slave
+      base.sharded = true
     end
-
-    private
-
-    attr_accessor :sharded
   end
 end


### PR DESCRIPTION
Sharding state is now controlled via #sharded class attribute:

```
    ActiveRecord::Base.sharded = true/false
    MyModel.sharded = true/false
```

I reworked the internals using a-rails-way `class_attribute` that is designed for easy to use per class configuration that works well with inheritance.

Fixes #170 