### PR TITLE
Require mocha 1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ pkg/*
 *.log
 Gemfile.lock
 gemfiles/*.lock
+vendor
+gemfiles/vendor
 .tags*
 tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,5 @@ pkg/*
 *.log
 Gemfile.lock
 gemfiles/*.lock
-vendor
-gemfiles/vendor
 .tags*
 tmp/*

--- a/README.md
+++ b/README.md
@@ -168,4 +168,4 @@ ActiveRecordShards::SqlComments.enable
 Copyright (c) 2011 Zendesk. See LICENSE for details.
 
 ## Authors
-Mick Staugaard, Eric Chapweske
+Mick Staugaard, Eric Chapweske 

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new "active_record_shards", "3.12.0.beta2" do |s|
   s.add_development_dependency("rubocop", "0.50.0")
   s.add_development_dependency("minitest")
   s.add_development_dependency("minitest-rg")
-  s.add_development_dependency("mocha")
+  s.add_development_dependency("mocha", ">= 1.4.0")
   s.add_development_dependency("phenix", ">= 0.2.0")
 
   s.files = Dir["lib/**/*"] + ["README.md"]


### PR DESCRIPTION
`require 'mocha/minitest'` requires at least mocha 1.4.0

/cc @bquorning @zendesk/classic-upgrade @zendesk/sustaining 

### Risks
None.