### PR TITLE
Require mocha 1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ pkg/*
 *.log
 Gemfile.lock
 gemfiles/*.lock
+vendor
+gemfiles/vendor
 .tags*
 tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,5 @@ pkg/*
 *.log
 Gemfile.lock
 gemfiles/*.lock
-vendor
-gemfiles/vendor
 .tags*
 tmp/*

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new "active_record_shards", "4.0.0.beta9" do |s|
   s.add_development_dependency("bump")
   s.add_development_dependency("minitest")
   s.add_development_dependency("minitest-rg")
-  s.add_development_dependency("mocha")
+  s.add_development_dependency("mocha", ">= 1.4.0")
   s.add_development_dependency("mysql2")
   s.add_development_dependency("phenix", ">= 0.2.0")
   s.add_development_dependency("rake", '~> 12.0')


### PR DESCRIPTION
`require 'mocha/minitest'` requires at least mocha 1.4.0

Same as #192, for the `v4` branch.

/cc @bquorning @grosser @pschambacher 

### Risks
None.