### PR TITLE
Tasks: correctly require adapters

### DIFF
--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -3,4 +3,7 @@ source 'https://rubygems.org'
 
 gemspec path: Bundler.root.to_s.sub('/gemfiles', '')
 
-gem "byebug", platforms: [:mri]
+group :test do
+  gem 'byebug', platforms: [:mri]
+  gem 'ar_mysql_flexmaster'
+end

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -30,23 +30,19 @@ namespace :db do
   task create: :load_config do
     ActiveRecord::Base.configurations.each do |key, conf|
       next if !key.starts_with?(ActiveRecordShards.rails_env) || key.ends_with?("_slave")
-      if ActiveRecord::VERSION::MAJOR >= 4
-        begin
-          # MysqlAdapter takes charset instead of encoding in Rails 4
-          # https://github.com/rails/rails/commit/78b30fed9336336694fb2cb5d2825f95800b541c
-          symbolized_configuration = conf.symbolize_keys
-          symbolized_configuration[:charset] = symbolized_configuration[:encoding]
+      begin
+        # MysqlAdapter takes charset instead of encoding in Rails 3.2 or greater
+        # https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/railties/databases.rake#L68-L82
+        symbolized_configuration = conf.symbolize_keys
+        symbolized_configuration[:charset] = symbolized_configuration[:encoding]
 
-          ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'], symbolized_configuration)
-        rescue ActiveRecord::StatementInvalid => ex
-          if ex.message.include?('database exists')
-            puts "#{conf['database']} already exists"
-          else
-            raise ex
-          end
+        ActiveRecordShards::Tasks.root_connection(conf).create_database(conf['database'], symbolized_configuration)
+      rescue ActiveRecord::StatementInvalid => ex
+        if ex.message.include?('database exists')
+          puts "#{conf['database']} already exists"
+        else
+          raise ex
         end
-      else
-        create_database(conf)
       end
     end
     ActiveRecord::Base.establish_connection(ActiveRecordShards.rails_env.to_sym)

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -85,22 +85,24 @@ end
 
 module ActiveRecordShards
   module Tasks
-    def self.root_connection(conf)
-      conf = conf.merge('database' => nil)
-      spec = spec_for(conf)
+    class << self
+      def root_connection(conf)
+        conf = conf.merge('database' => nil)
+        spec = spec_for(conf)
 
-      ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.config)
-    end
+        ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.config)
+      end
 
-    private
+      private
 
-    def self.spec_for(conf)
-      if ActiveRecord::VERSION::MAJOR >= 4
-        resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations)
-        resolver.spec(conf)
-      else
-        resolver = ActiveRecordShards::ConnectionSpecification::Resolver.new conf, ActiveRecord::Base.configurations
-        resolver.spec
+      def spec_for(conf)
+        if ActiveRecord::VERSION::MAJOR >= 4
+          resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations)
+          resolver.spec(conf)
+        else
+          resolver = ActiveRecordShards::ConnectionSpecification::Resolver.new conf, ActiveRecord::Base.configurations
+          resolver.spec
+        end
       end
     end
   end

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -85,20 +85,18 @@ end
 
 module ActiveRecordShards
   module Tasks
-    if ActiveRecord::VERSION::MAJOR >= 4
-      def self.root_connection(conf)
-        conf = conf.merge('database' => nil)
+    def self.root_connection(conf)
+      conf = conf.merge('database' => nil)
+
+      spec = if ActiveRecord::VERSION::MAJOR >= 4
         resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations)
         resolver.spec(conf)
-        ActiveRecord::Base.send("#{conf['adapter']}_connection", conf)
-      end
-    else
-      def self.root_connection(conf)
-        conf = conf.merge('database' => nil)
+      else
         resolver = ActiveRecordShards::ConnectionSpecification::Resolver.new conf, ActiveRecord::Base.configurations
-        spec = resolver.spec
-        ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.config)
+        resolver.spec
       end
+
+      ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.config)
     end
   end
 end

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -87,16 +87,21 @@ module ActiveRecordShards
   module Tasks
     def self.root_connection(conf)
       conf = conf.merge('database' => nil)
+      spec = spec_for(conf)
 
-      spec = if ActiveRecord::VERSION::MAJOR >= 4
+      ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.config)
+    end
+
+    private
+
+    def self.spec_for(conf)
+      if ActiveRecord::VERSION::MAJOR >= 4
         resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations)
         resolver.spec(conf)
       else
         resolver = ActiveRecordShards::ConnectionSpecification::Resolver.new conf, ActiveRecord::Base.configurations
         resolver.spec
       end
-
-      ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.config)
     end
   end
 end

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -89,17 +89,19 @@ end
 
 module ActiveRecordShards
   module Tasks
-    if ActiveRecord::VERSION::MAJOR < 5
+    if ActiveRecord::VERSION::MAJOR >= 4
       def self.root_connection(conf)
-        ActiveRecord::Base.send("#{conf['adapter']}_connection", conf.merge('database' => nil))
-      end
-    else
-      def self.root_connection(conf)
-        # this will trigger rails to load the adapter
         conf = conf.merge('database' => nil)
         resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations)
         resolver.spec(conf)
         ActiveRecord::Base.send("#{conf['adapter']}_connection", conf)
+      end
+    else
+      def self.root_connection(conf)
+        conf = conf.merge('database' => nil)
+        resolver = ActiveRecordShards::ConnectionSpecification::Resolver.new conf, ActiveRecord::Base.configurations
+        spec = resolver.spec
+        ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.config)
       end
     end
   end

--- a/test/database_tasks.yml
+++ b/test/database_tasks.yml
@@ -2,11 +2,15 @@
 
 mysql: &MYSQL
   encoding: utf8
-  database: ars_tasks_test
   username: <%= mysql.user %>
   password: <%= mysql.password %>
   host: <%= mysql.host %>
   port: <%= mysql.port %>
+
+test:
+  <<: *MYSQL
+  adapter: mysql2
+  database: ars_tasks_test
   slave:
     database: ars_tasks_test_slave
   shards:
@@ -15,10 +19,14 @@ mysql: &MYSQL
     1:
       database: ars_tasks_test_shard_b
 
-test:
-  <<: *MYSQL
-  adapter: mysql2
-
 test_flexmaster:
   <<: *MYSQL
   adapter: mysql_flexmaster
+  database: ars_tasks_flex_test
+  slave:
+    database: ars_tasks_flex_test_slave
+  shards:
+    0:
+      database: ars_tasks_flex_test_shard_a
+    1:
+      database: ars_tasks_flex_test_shard_b

--- a/test/database_tasks.yml
+++ b/test/database_tasks.yml
@@ -1,6 +1,6 @@
 <% mysql = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306') %>
-test:
-  adapter: mysql2
+
+mysql: &MYSQL
   encoding: utf8
   database: ars_tasks_test
   username: <%= mysql.user %>
@@ -14,3 +14,11 @@ test:
       database: ars_tasks_test_shard_a
     1:
       database: ars_tasks_test_shard_b
+
+test:
+  <<: *MYSQL
+  adapter: mysql2
+
+test_flexmaster:
+  <<: *MYSQL
+  adapter: mysql_flexmaster


### PR DESCRIPTION
If using an adapter that wasn't required before, `root_connection` would raise. Apply same fix used for Rails 5 to Rails 3/4.

By adding test with different adapter, also found out it would not work when creating a table with rails 3.2 (was breaking here https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/railties/databases.rake#L112). Applied same fix from Rails 4/5 to Rails 3.2. I'm not entirely sure on that one, but tests are all green, so looks fine?

/cc @bquorning @grosser @pschambacher 

### Risks
Medium. Might break rake tasks.