### PR TITLE
Clean up test helpers

### DIFF
--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -2,6 +2,9 @@
 require_relative 'helper'
 
 describe "connection switching" do
+  include ConnectionSwitchingSpecHelpers
+  extend RailsEnvSwitch
+
   def clear_connection_pool
     if ActiveRecord::VERSION::MAJOR >= 4
       ActiveRecord::Base.connection_handler.connection_pool_list.clear

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -304,7 +304,7 @@ describe "connection switching" do
         assert UnshardedModel.table_exists?
 
         ActiveRecord::Base.on_all_shards do
-          refute ActiveRecord::Base.connection.public_send(connection_exist_method, "unsharded_models")
+          refute table_exists?("unsharded_models")
         end
       end
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,10 +25,6 @@ ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + "/test.log")
 ActiveSupport.test_order = :sorted if ActiveSupport.respond_to?(:test_order=)
 ActiveSupport::Deprecation.behavior = :raise
 
-def connection_exist_method
-  ActiveRecord::VERSION::MAJOR == 5 ? :data_source_exists? : :table_exists?
-end
-
 BaseMigration = (ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration) # rubocop:disable Naming/ConstantName
 
 require 'active_support/test_case'
@@ -78,6 +74,14 @@ module ConnectionSwitchingSpecHelpers
 end
 
 module SpecHelpers
+  def table_exists?(name)
+    if ActiveRecord::VERSION::MAJOR == 5
+      ActiveRecord::Base.connection.data_source_exists?(name)
+    else
+      ActiveRecord::Base.connection.table_exists?(name)
+    end
+  end
+
   def table_has_column?(table, column)
     !ActiveRecord::Base.connection.select_values("desc #{table}").grep(column).empty?
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -34,29 +34,18 @@ BaseMigration = (ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[4.2
 require 'active_support/test_case'
 
 # support multiple before/after blocks per example
-Minitest::Spec::DSL.class_eval do
-  remove_method :before
+module SpecDslPatch
   def before(_type = nil, &block)
-    include(Module.new do
-      define_method(:setup) do
-        super()
-        instance_exec(&block)
-      end
-    end)
+    include(Module.new { super })
   end
 
-  remove_method :after
   def after(_type = nil, &block)
-    include(Module.new do
-      define_method(:teardown) do
-        instance_exec(&block)
-        super()
-      end
-    end)
+    include(Module.new { super })
   end
 end
+Minitest::Spec.singleton_class.prepend(SpecDslPatch)
 
-Minitest::Spec.class_eval do
+module RakeSpecHelpers
   def show_databases(config)
     client = Mysql2::Client.new(
       host: config['test']['host'],
@@ -72,7 +61,9 @@ Minitest::Spec.class_eval do
     Rake::Task[name].reenable
     Rake::Task[name].invoke
   end
+end
 
+module ConnectionSwitchingSpecHelpers
   def assert_using_master_db
     assert_using_database('ars_test')
   end
@@ -84,7 +75,9 @@ Minitest::Spec.class_eval do
   def assert_using_database(db_name, model = ActiveRecord::Base)
     assert_equal(db_name, model.connection.current_database)
   end
+end
 
+module SpecHelpers
   def table_has_column?(table, column)
     !ActiveRecord::Base.connection.select_values("desc #{table}").grep(column).empty?
   end
@@ -101,8 +94,11 @@ Minitest::Spec.class_eval do
       ActiveRecord::Migrator.new(direction, migration_path, target_version)
     end
   end
+end
+Minitest::Spec.include(SpecHelpers)
 
-  def self.switch_rails_env(env)
+module RailsEnvSwitch
+  def switch_rails_env(env)
     before do
       silence_warnings { Object.const_set("RAILS_ENV", env) }
       ActiveRecord::Base.establish_connection(::RAILS_ENV.to_sym)
@@ -113,10 +109,12 @@ Minitest::Spec.class_eval do
       assert_using_database('ars_test', Ticket)
     end
   end
+end
 
+module PhenixHelper
   # create all databases and then tear them down after test
   # avoid doing any shard switching while preparing our databases
-  def self.with_phenix
+  def with_phenix
     before do
       ActiveRecord::Base.stubs(:with_default_shard).yields
 
@@ -146,3 +144,4 @@ Minitest::Spec.class_eval do
     end
   end
 end
+Minitest::Spec.extend(PhenixHelper)

--- a/test/migrator_test.rb
+++ b/test/migrator_test.rb
@@ -12,9 +12,9 @@ describe ActiveRecord::Migrator do
     migrator.migrate
 
     ActiveRecord::Base.on_all_shards do
-      assert ActiveRecord::Base.connection.public_send(connection_exist_method, :schema_migrations), "Schema Migrations doesn't exist"
-      assert ActiveRecord::Base.connection.public_send(connection_exist_method, :tickets)
-      refute ActiveRecord::Base.connection.public_send(connection_exist_method, :accounts)
+      assert table_exists?(:schema_migrations), "Schema Migrations doesn't exist"
+      assert table_exists?(:tickets)
+      refute table_exists?(:accounts)
       assert ActiveRecord::Base.connection.select_value("select version from schema_migrations where version = '20110824010216'")
       assert ActiveRecord::Base.connection.select_value("select version from schema_migrations where version = '20110829215912'")
     end

--- a/test/schema_dumper_extension_test.rb
+++ b/test/schema_dumper_extension_test.rb
@@ -26,7 +26,7 @@ if ActiveRecord::VERSION::MAJOR >= 4
         load(schema_file)
 
         ActiveRecord::Base.on_all_shards do
-          assert ActiveRecord::Base.connection.public_send(connection_exist_method, :schema_migrations), "Schema Migrations doesn't exist"
+          assert table_exists?(:schema_migrations), "Schema Migrations doesn't exist"
           assert ActiveRecord::Base.connection.select_value("select version from schema_migrations where version = '20110824010216'")
           assert ActiveRecord::Base.connection.select_value("select version from schema_migrations where version = '20110829215912'")
         end

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -10,6 +10,8 @@ task :environment do
 end
 
 describe "Database rake tasks" do
+  include RakeSpecHelpers
+
   def capture_stderr
     $stderr = StringIO.new
     yield


### PR DESCRIPTION
This PR removes a couple of `class_eval`s from the test helper file. I think using `prepend` and plain module inclusion makes it easier to understand what is included where.

By splitting the helper methods into modules it’s also possible to not include everything everywhere, as seen in the changes to test/connection_switching_test.rb and test/tasks_test.rb.

Includes @bogdan’s `table_exists?` method from #191.