### PR TITLE
Fix ShardSelection bug

### DIFF
--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -24,6 +24,8 @@ module ActiveRecordShards
       def shard_name(klass = nil, try_slave = true)
         the_shard = shard(klass)
 
+        raise "Cannot find connection for sharded class when no shard is selected." if klass.is_sharded? && !the_shard
+
         @shard_names ||= {}
         @shard_names[ActiveRecordShards.rails_env] ||= {}
         @shard_names[ActiveRecordShards.rails_env][the_shard] ||= {}
@@ -39,7 +41,7 @@ module ActiveRecordShards
     else
 
       def shard
-        if @shard.nil? || @shard == NO_SHARD
+        if @shard == NO_SHARD
           nil
         else
           @shard || self.class.default_shard
@@ -50,6 +52,8 @@ module ActiveRecordShards
       def resolve_connection_name(sharded:, configurations:)
         resolved_shard = sharded ? shard : nil
         env = ActiveRecordShards.rails_env
+
+        raise "Cannot find connection for sharded class when no shard is selected." if sharded && !shard
 
         @connection_names ||= {}
         @connection_names[env] ||= {}

--- a/test/shard_selection_test.rb
+++ b/test/shard_selection_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+describe ActiveRecordShards::ShardSelection do
+  require 'models'
+
+  before do
+    erb_config = IO.read("#{__dir__}/database.yml")
+    yaml_config = ERB.new(erb_config).result
+    db_config = YAML.load(yaml_config) # rubocop:disable Security/YAMLLoad
+    ActiveRecord::Base.configurations = db_config
+  end
+
+  after do
+    ActiveRecordShards::ShardSelection.default_shard = nil
+  end
+
+  describe "sharded model" do
+    it "complains when no shard is selected" do
+      shard_selection = ActiveRecordShards::ShardSelection.new
+
+      assert_raises("Cannot find connection for sharded class when no shard is selected.") { connection_name(shard_selection, Ticket) }
+    end
+
+    it "complains when no shard is selected even if told to use the slave" do
+      shard_selection = ActiveRecordShards::ShardSelection.new
+      shard_selection.on_slave = true
+
+      assert_raises("Cannot find connection for sharded class when no shard is selected.") { connection_name(shard_selection, Ticket) }
+    end
+
+    it "returns the correct sharded master connection name" do
+      shard_selection = ActiveRecordShards::ShardSelection.new
+      shard_selection.shard = 0
+
+      assert_equal "test_shard_0", connection_name(shard_selection, Ticket)
+    end
+
+    it "returns the correct sharded slave connection name" do
+      shard_selection = ActiveRecordShards::ShardSelection.new
+      shard_selection.shard = 0
+      shard_selection.on_slave = true
+
+      assert_equal "test_shard_0_slave", connection_name(shard_selection, Ticket)
+    end
+
+    describe "with default_shard set" do
+      it "returns the correct sharded master connection name" do
+        ActiveRecordShards::ShardSelection.default_shard = 1
+        shard_selection = ActiveRecordShards::ShardSelection.new
+
+        assert_equal "test_shard_1", connection_name(shard_selection, Ticket)
+      end
+
+      it "returns the correct sharded slave connection name" do
+        ActiveRecordShards::ShardSelection.default_shard = 1
+        shard_selection = ActiveRecordShards::ShardSelection.new
+        shard_selection.on_slave = true
+
+        assert_equal "test_shard_1_slave", connection_name(shard_selection, Ticket)
+      end
+
+      it "returns the correct sharded master connection name when overriding shard number" do
+        ActiveRecordShards::ShardSelection.default_shard = 1
+        shard_selection = ActiveRecordShards::ShardSelection.new
+        shard_selection.shard = 0
+
+        assert_equal "test_shard_0", connection_name(shard_selection, Ticket)
+      end
+
+      it "returns the correct sharded slave connection name when overriding shard number" do
+        ActiveRecordShards::ShardSelection.default_shard = 1
+        shard_selection = ActiveRecordShards::ShardSelection.new
+        shard_selection.on_slave = true
+        shard_selection.shard = 0
+
+        assert_equal "test_shard_0_slave", connection_name(shard_selection, Ticket)
+      end
+    end
+  end
+
+  describe "unsharded model" do
+    it "returns the unsharded master connection name" do
+      shard_selection = ActiveRecordShards::ShardSelection.new
+
+      # Two different names for the same connection
+      assert_includes ["primary", "test"], connection_name(shard_selection, Account)
+    end
+
+    it "returns the unsharded slave connection name" do
+      shard_selection = ActiveRecordShards::ShardSelection.new
+      shard_selection.on_slave = true
+
+      assert_equal "test_slave", connection_name(shard_selection, Account)
+    end
+  end
+
+  private
+
+  def connection_name(shard_selection, klass)
+    if ActiveRecord::VERSION::MAJOR < 5
+      shard_selection.shard_name(klass)
+    else
+      shard_selection.resolve_connection_name(sharded: klass.is_sharded?, configurations: klass.configurations)
+    end
+  end
+end


### PR DESCRIPTION
I found a bug where `ShardSelection.resolve_connection_name` would return `"primary"` for a sharded model when no shard is selected. Since we don’t want a “sharded query” to be performed against the unsharded database, I want to raise an exception as early as possible.

But now we have a bunch of tests failing. @pschambacher can you help me out here?