### PR TITLE
Create Rails internal tables on all shards

### DIFF
--- a/lib/active_record_shards/connection_switcher-4-0.rb
+++ b/lib/active_record_shards/connection_switcher-4-0.rb
@@ -48,6 +48,11 @@ module ActiveRecordShards
       @@specification_cache ||= {}
     end
 
+    # Helper method to clear global state when testing.
+    def clear_specification_cache
+      @@specification_cache = {}
+    end
+
     def connection_pool_key
       specification_cache[connection_pool_name]
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -69,6 +69,16 @@ module ConnectionSwitchingSpecHelpers
 end
 
 module SpecHelpers
+  def clear_global_connection_handler_state
+    # Use a fresh connection handler
+    ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+
+    if ActiveRecord::VERSION::MAJOR <= 4
+      # Clear out our own global state
+      ActiveRecord::Base.send(:clear_specification_cache)
+    end
+  end
+
   def table_exists?(name)
     if ActiveRecord::VERSION::MAJOR == 5
       ActiveRecord::Base.connection.data_source_exists?(name)
@@ -116,6 +126,8 @@ module PhenixHelper
   # avoid doing any shard switching while preparing our databases
   def with_phenix
     before do
+      clear_global_connection_handler_state
+
       ActiveRecord::Base.stubs(:with_default_shard).yields
 
       # Create intentionally empty databases

--- a/test/separate_migrations/20190121112233_separate_unsharded_migration.rb
+++ b/test/separate_migrations/20190121112233_separate_unsharded_migration.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class SeparateUnshardedMigration < BaseMigration
+  shard :none
+
+  def self.up
+    create_table :unsharded_table do |t|
+      t.string :name
+    end
+  end
+
+  def self.down
+  end
+end

--- a/test/separate_migrations/20190121112234_separate_sharded_migration.rb
+++ b/test/separate_migrations/20190121112234_separate_sharded_migration.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class SeparateShardedMigration < BaseMigration
+  shard :all
+
+  def self.up
+    create_table :sharded_table do |t|
+      t.string :name
+    end
+  end
+
+  def self.down
+  end
+end

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -27,6 +27,8 @@ describe "Database rake tasks" do
   let(:database_names) { shard_names + [master_name, slave_name] }
 
   before do
+    clear_global_connection_handler_state
+
     if ActiveRecord::VERSION::MAJOR >= 4
       ActiveRecord::Tasks::DatabaseTasks.database_configuration = config
       ActiveRecord::Tasks::DatabaseTasks.env = RAILS_ENV


### PR DESCRIPTION
Two Rails support tables (by default named `schema_migrations` and `ar_internal_metadata`) were only created on the unsharded database. By patching the `Migration` initializer they are now also created on all sharded databases.

Closes #191, which was the inspiration for this PR.