### PR TITLE
Test and support Ruby >=2.2 and <=2.6 only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,22 +10,15 @@ test: &test
 jobs:
 
   # Rails 3.2
-  ruby-2.2-rails-3.2-test:
+  ruby-2.3-rails-3.2-test:
     docker:
-      - image: circleci/ruby:2.2
+      - image: circleci/ruby:2.3
       - image: circleci/mysql:5.6-ram # Not compatible with MySQL 5.7
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails3.2.gemfile
     <<: *test
 
   # Rails 4.2
-  ruby-2.2-rails-4.2-test:
-    docker:
-      - image: circleci/ruby:2.2
-      - image: circleci/mysql:5.7-ram
-    environment:
-      - BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
-    <<: *test
   ruby-2.3-rails-4.2-test:
     docker:
       - image: circleci/ruby:2.3
@@ -47,24 +40,24 @@ jobs:
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
     <<: *test
+  ruby-2.6-rails-4.2-test:
+    docker:
+      - image: circleci/ruby:2.6
+      - image: circleci/mysql:5.7-ram
+    environment:
+      - BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
+    <<: *test
 
   # Rails 5.0
-  ruby-2.5-rails-5.0-test:
+  ruby-2.6-rails-5.0-test:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.6
       - image: circleci/mysql:5.7-ram
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails5.0.gemfile
     <<: *test
 
   # Rails 5.1
-  ruby-2.2-rails-5.1-test:
-    docker:
-      - image: circleci/ruby:2.2
-      - image: circleci/mysql:5.7-ram
-    environment:
-      - BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
-    <<: *test
   ruby-2.3-rails-5.1-test:
     docker:
       - image: circleci/ruby:2.3
@@ -86,15 +79,15 @@ jobs:
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
     <<: *test
-
-  # Rails 5.2
-  ruby-2.2-rails-5.2-test:
+  ruby-2.6-rails-5.1-test:
     docker:
-      - image: circleci/ruby:2.2
+      - image: circleci/ruby:2.6
       - image: circleci/mysql:5.7-ram
     environment:
-      - BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
+      - BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
     <<: *test
+
+  # Rails 5.2
   ruby-2.3-rails-5.2-test:
     docker:
       - image: circleci/ruby:2.3
@@ -116,11 +109,18 @@ jobs:
     environment:
       - BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
     <<: *test
+  ruby-2.6-rails-5.2-test:
+    docker:
+      - image: circleci/ruby:2.6
+      - image: circleci/mysql:5.7-ram
+    environment:
+      - BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
+    <<: *test
 
   # Rubocop
   rubocop:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby
     steps:
       - checkout
       - run: bundle install
@@ -132,21 +132,21 @@ workflows:
     jobs:
       - rubocop
 
-      - ruby-2.2-rails-3.2-test
+      - ruby-2.3-rails-3.2-test
 
-      - ruby-2.2-rails-4.2-test
       - ruby-2.3-rails-4.2-test
       - ruby-2.4-rails-4.2-test
       - ruby-2.5-rails-4.2-test
+      - ruby-2.6-rails-4.2-test
 
-      - ruby-2.5-rails-5.0-test
+      - ruby-2.6-rails-5.0-test
 
-      - ruby-2.2-rails-5.1-test
       - ruby-2.3-rails-5.1-test
       - ruby-2.4-rails-5.1-test
       - ruby-2.5-rails-5.1-test
+      - ruby-2.6-rails-5.1-test
 
-      - ruby-2.2-rails-5.2-test
       - ruby-2.3-rails-5.2-test
       - ruby-2.4-rails-5.2-test
       - ruby-2.5-rails-5.2-test
+      - ruby-2.6-rails-5.2-test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - .git/**/*
     - gemfiles/vendor/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3
 
 # Configured cops
 
@@ -85,6 +85,9 @@ Style/Documentation:
 Style/DoubleNegation:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/GuardClause:
   Enabled: false
 
@@ -92,6 +95,9 @@ Style/IfUnlessModifier:
   Enabled: false
 
 Style/NumericLiterals:
+  Enabled: false
+
+Style/RedundantFreeze:
   Enabled: false
 
 Style/StringLiterals:

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new "active_record_shards", "3.12.0.beta2" do |s|
   s.description = "Easily run queries on shard and slave databases."
   s.license     = "MIT"
 
-  s.required_ruby_version = "~> 2.0"
+  s.required_ruby_version = ">= 2.3"
 
   s.add_runtime_dependency("activerecord", ">= 3.2.16", "< 6.0")
   s.add_runtime_dependency("activesupport", ">= 3.2.16", "< 6.0")


### PR DESCRIPTION
Remove mentions of Ruby 2.1 and 2.2. Start testing with 2.6.

A number of required builds are of course not built – because they are moved by this PR.