### PR TITLE
Close active connections in test

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -70,6 +70,9 @@ end
 
 module SpecHelpers
   def clear_global_connection_handler_state
+    # Close active connections
+    ActiveRecord::Base.connection_handler.clear_all_connections!
+
     # Use a fresh connection handler
     ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
 


### PR DESCRIPTION
When we started creating a new ConnectionHandler before each test, we started creating a HUUUGE number of connections to MySQL. Of course, we need to ask ActiveRecord to close the active connections before adding a the ConnectionHandler.

Fixes e.g. https://circleci.com/gh/zendesk/active_record_shards/1178 – oops.