### PR TITLE
Revert "ActiveRecord::InternalMetadata is not sharded"

### DIFF
--- a/lib/active_record_shards/patches-5-0.rb
+++ b/lib/active_record_shards/patches-5-0.rb
@@ -11,5 +11,3 @@ require 'active_record_shards/schema_dumper_extension'
 ActiveRecord::Associations::Builder::HasAndBelongsToMany.include(ActiveRecordShards::DefaultSlavePatches::Rails41HasAndBelongsToManyBuilderExtension)
 
 ActiveRecord::SchemaDumper.prepend(ActiveRecordShards::SchemaDumperExtension)
-
-ActiveRecord::InternalMetadata.not_sharded

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -258,35 +258,6 @@ describe "connection switching" do
         table_has_column?('schema_migrations', 'foo')
       end
     end
-
-    if ActiveRecord::VERSION::MAJOR >= 5
-      describe "for InternalMetadata" do
-        before do
-          ActiveRecord::InternalMetadata.on_slave do
-            ActiveRecord::InternalMetadata.connection.execute("alter table ar_internal_metadata add column foo int")
-            ActiveRecord::InternalMetadata.reset_column_information
-          end
-        end
-
-        after do
-          ActiveRecord::InternalMetadata.on_slave do
-            ActiveRecord::Base.connection.execute("alter table ar_internal_metadata drop column foo")
-            ActiveRecord::InternalMetadata.reset_column_information
-            refute ActiveRecord::InternalMetadata.column_names.include?('foo')
-          end
-        end
-
-        it "use the non-sharded slave connection" do
-          assert_using_database('ars_test', ActiveRecord::InternalMetadata)
-          assert ActiveRecord::InternalMetadata.column_names.include?('foo')
-        end
-
-        it "ignores master/transactions" do
-          assert_using_database('ars_test', ActiveRecord::InternalMetadata)
-          ActiveRecord::InternalMetadata.on_master { assert ActiveRecord::InternalMetadata.column_names.include?('foo') }
-        end
-      end
-    end
   end
 
   describe "ActiveRecord::Base.table_exists?" do


### PR DESCRIPTION
Reverts zendesk/active_record_shards#125

`ar_internal_metadata` should exist on both sharded and unsharded tables – see #209.