### PR TITLE
requiring sql_comments should not connect to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 test: &test
   steps:
     - checkout
-    - run: sudo apt install mysql-client || sudo apt-get update && sudo apt install mysql-client
+    - run: sudo apt install default-mysql-client || sudo apt-get update && sudo apt install default-mysql-client
     - run: bundle install
     - run: rake test
 

--- a/lib/active_record_shards/connection_switcher-4-0.rb
+++ b/lib/active_record_shards/connection_switcher-4-0.rb
@@ -4,6 +4,7 @@ module ActiveRecordShards
     def connection_pool_name # :nodoc:
       name = current_shard_selection.shard_name(self)
 
+      # e.g. if "production_slave" is not defined in `Configuration`, fall back to "production"
       if configurations[name].nil? && on_slave?
         current_shard_selection.shard_name(self, false)
       else

--- a/lib/active_record_shards/sql_comments.rb
+++ b/lib/active_record_shards/sql_comments.rb
@@ -10,7 +10,11 @@ module ActiveRecordShards
     end
 
     def self.enable
-      ActiveRecord::Base.on_shard(nil) { ActiveRecord::Base.connection.class.prepend(Methods) }
+      ActiveRecord::Base.on_slave do
+        ActiveRecord::Base.on_shard(nil) do
+          ActiveRecord::Base.connection.class.prepend(Methods)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I've been hunting down unnecessary connections to the master database during boot. I've been using sql_comments to help identify this problem in development. However, just requiring this file _causes_ a master connection during the patch process.

This is only used in development and console use.

cc @zendesk/database-gem-owners @craig-day 