### PR TITLE
TP-163 Rails 4 `where` and `having` statements should use the slave by default

### DIFF
--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -96,6 +96,11 @@ module ActiveRecordShards
         [:calculate, :exists?, :pluck, :load].each do |m|
           ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, m)
         end
+
+        if ActiveRecord::VERSION::MAJOR == 4
+          # `where` and `having` clauses call `create_binds`, which will use the master connection
+          ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :create_binds)
+        end
       end
 
       def on_slave_unless_tx


### PR DESCRIPTION
In Rails 4, if you call `Account.where` or `Account.having`, it opens a connection to the master database for utilizing bind methods on the adapter. When the master is unavailable, this causes issues for:

- Regular `Account.where(foo: bar).all` query building
- Calls to `Account.first` when using soft_deletion or default_scopes

cc @zendesk/database-gem-owners 

I'm not sure how to test this short of poisoning `ActiveRecord::Base.configurations`. Do we care?