### PR TITLE
Use explicit block argument

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -31,9 +31,9 @@ module ActiveRecordShards
       switch_connection(old_options)
     end
 
-    def on_first_shard
+    def on_first_shard(&block)
       shard_name = shard_names.first
-      on_shard(shard_name) { yield }
+      on_shard(shard_name, &block)
     end
 
     def shards
@@ -170,9 +170,9 @@ module ActiveRecordShards
       ActiveRecordShards.rails_env
     end
 
-    def with_default_shard
+    def with_default_shard(&block)
       if is_sharded? && current_shard_id.nil? && table_name != ActiveRecord::SchemaMigration.table_name
-        on_first_shard { yield }
+        on_first_shard(&block)
       else
         yield
       end

--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -83,9 +83,9 @@ module ActiveRecordShards
       end
     end
 
-    def on_slave_unless_tx
+    def on_slave_unless_tx(&block)
       if on_slave_by_default? && !Thread.current[:_active_record_shards_slave_off]
-        on_slave { yield }
+        on_slave(&block)
       else
         yield
       end
@@ -103,8 +103,8 @@ module ActiveRecordShards
         end
       end
 
-      def on_slave_unless_tx
-        @klass.on_slave_unless_tx { yield }
+      def on_slave_unless_tx(&block)
+        @klass.on_slave_unless_tx(&block)
       end
     end
 


### PR DESCRIPTION
I noticed this in my recent debugging, and those extra block frames in the backtrace make navigating byebug an even less pleasant experience.

Note that https://github.com/rubocop-hq/ruby-style-guide#block-argument says:

> Beware of the performance impact, though, as the block gets converted to a Proc.

So let's benchmark it:

```ruby
def bad
  doit { yield }
end

def good(&block)
  doit(&block)
end

def doit
  yield
end

require 'benchmark/ips'
Benchmark.ips do |x|
  x.report("bad") { bad { true } }
  x.report("good") { good { true } }
  x.compare!
end
```

```
for i in 2.3.8 2.4.6 2.5.4 2.6.3 2.7.0-preview1; do rbenv shell $i; echo "Using $i"; ruby benchmark.rb; done
Using 2.3.8
Warming up --------------------------------------
                 bad   294.327k i/100ms
                good   136.777k i/100ms
Calculating -------------------------------------
                 bad      7.988M (± 2.4%) i/s -     40.028M in   5.014276s
                good      2.009M (± 4.4%) i/s -     10.121M in   5.049121s

Comparison:
                 bad:  7988146.9 i/s
                good:  2008929.2 i/s - 3.98x  slower

Using 2.4.6
Warming up --------------------------------------
                 bad   176.524k i/100ms
                good   109.129k i/100ms
Calculating -------------------------------------
                 bad      7.813M (± 1.4%) i/s -     39.188M
                good      2.071M (± 2.1%) i/s -     10.367M

Comparison:
                 bad:  7812757.2 i/s
                good:  2071324.1 i/s - 3.77x slower

Using 2.5.4
Warming up --------------------------------------
                 bad   310.620k i/100ms
                good   315.893k i/100ms
Calculating -------------------------------------
                 bad      7.672M (± 5.4%) i/s -     38.517M in   5.037522s
                good      7.941M (± 3.6%) i/s -     39.803M in   5.019756s

Comparison:
                good:  7940873.5 i/s
                 bad:  7671869.9 i/s - same-ish: difference falls within error

Using 2.6.3
Warming up --------------------------------------
                 bad   349.799k i/100ms
                good   329.577k i/100ms
Calculating -------------------------------------
                 bad     11.089M (± 1.6%) i/s -     55.618M in   5.017068s
                good     10.692M (± 1.3%) i/s -     53.721M in   5.025193s

Comparison:
                 bad: 11088925.8 i/s
                good: 10692191.0 i/s - 1.04x  slower

Using 2.7.0-preview1
Warming up --------------------------------------
                 bad   346.921k i/100ms
                good   348.950k i/100ms
Calculating -------------------------------------
                 bad     10.161M (± 1.8%) i/s -     50.997M in   5.020766s
                good      9.903M (± 1.8%) i/s -     49.551M in   5.005300s

Comparison:
                 bad: 10160763.4 i/s
                good:  9902927.6 i/s - same-ish: difference falls within error
```

We still have a service on a 2.4, but I don't think this the impact is significant enough to refute the change.

Also @bquorning I'll have a following PR, so don't bother releasing immediately unless you enjoy it.