### PR TITLE
Force `.where(..).to_sql` to use slave connection, since it's only for escaping

### DIFF
--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -101,7 +101,7 @@ module ActiveRecordShards
 
         if ActiveRecord::VERSION::MAJOR == 4
           # `where` and `having` clauses call `create_binds`, which will use the master connection
-          ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :create_binds)
+          ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :create_binds, true)
         end
       end
 

--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module ActiveRecordShards
   module DefaultSlavePatches
-    def self.wrap_method_in_on_slave(class_method, base, method, force_on_slave = false)
+    def self.wrap_method_in_on_slave(class_method, base, method, force_on_slave: false)
       base_methods =
         if class_method
           base.methods + base.private_methods
@@ -69,7 +69,7 @@ module ActiveRecordShards
 
     def self.extended(base)
       CLASS_SLAVE_METHODS.each { |m| ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(true, base, m) }
-      CLASS_FORCE_SLAVE_METHODS.each { |m| ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(true, base, m, true) }
+      CLASS_FORCE_SLAVE_METHODS.each { |m| ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(true, base, m, force_on_slave: true) }
 
       base.class_eval do
         include InstanceMethods
@@ -105,10 +105,10 @@ module ActiveRecordShards
 
         if ActiveRecord::VERSION::MAJOR == 4
           # `where` and `having` clauses call `create_binds`, which will use the master connection
-          ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :create_binds, true)
+          ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :create_binds, force_on_slave: true)
         end
 
-        ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :to_sql, true)
+        ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :to_sql, force_on_slave: true)
       end
 
       def on_slave_unless_tx(&block)

--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -60,6 +60,10 @@ module ActiveRecordShards
 
     CLASS_FORCE_SLAVE_METHODS = [
       :columns,
+      :replace_bind_variable,
+      :replace_bind_variables,
+      :sanitize_sql_array,
+      :sanitize_sql_hash_for_assignment,
       :table_exists?
     ].freeze
 
@@ -103,6 +107,8 @@ module ActiveRecordShards
           # `where` and `having` clauses call `create_binds`, which will use the master connection
           ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :create_binds, true)
         end
+
+        ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(false, base, :to_sql, true)
       end
 
       def on_slave_unless_tx(&block)

--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -48,8 +48,20 @@ module ActiveRecordShards
       end
     end
 
-    CLASS_SLAVE_METHODS = [:find_by_sql, :count_by_sql, :calculate, :find_one, :find_some, :find_every, :exists?].freeze
-    CLASS_FORCE_SLAVE_METHODS = [:columns, :table_exists?].freeze
+    CLASS_SLAVE_METHODS = [
+      :calculate,
+      :count_by_sql,
+      :exists?,
+      :find_by_sql,
+      :find_every,
+      :find_one,
+      :find_some
+    ].freeze
+
+    CLASS_FORCE_SLAVE_METHODS = [
+      :columns,
+      :table_exists?
+    ].freeze
 
     def self.extended(base)
       CLASS_SLAVE_METHODS.each { |m| ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(true, base, m) }

--- a/lib/active_record_shards/default_slave_patches.rb
+++ b/lib/active_record_shards/default_slave_patches.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module ActiveRecordShards
   module DefaultSlavePatches
-    def self.wrap_method_in_on_slave(class_method, base, method)
+    def self.wrap_method_in_on_slave(class_method, base, method, force_on_slave = false)
       base_methods =
         if class_method
           base.methods + base.private_methods
@@ -11,10 +11,12 @@ module ActiveRecordShards
 
       return unless base_methods.include?(method)
       _, method, punctuation = method.to_s.match(/^(.*?)([\?\!]?)$/).to_a
+      # _ALWAYS_ on slave, or only for on `on_slave_by_default = true` models?
+      wrapper = force_on_slave ? 'force_on_slave' : 'on_slave_unless_tx'
       base.class_eval <<-RUBY, __FILE__, __LINE__ + 1
         #{class_method ? 'class << self' : ''}
           def #{method}_with_default_slave#{punctuation}(*args, &block)
-            on_slave_unless_tx do
+            #{wrapper} do
               #{method}_without_default_slave#{punctuation}(*args, &block)
             end
           end
@@ -23,18 +25,6 @@ module ActiveRecordShards
           alias_method :#{method}#{punctuation}, :#{method}_with_default_slave#{punctuation}
         #{class_method ? 'end' : ''}
       RUBY
-    end
-
-    def columns_with_force_slave(*args, &block)
-      on_cx_switch_block(:slave, construct_ro_scope: false, force: true) do
-        columns_without_force_slave(*args, &block)
-      end
-    end
-
-    def table_exists_with_force_slave?(*args, &block)
-      on_cx_switch_block(:slave, construct_ro_scope: false, force: true) do
-        table_exists_without_force_slave?(*args, &block)
-      end
     end
 
     def transaction_with_slave_off(*args, &block)
@@ -59,20 +49,16 @@ module ActiveRecordShards
     end
 
     CLASS_SLAVE_METHODS = [:find_by_sql, :count_by_sql, :calculate, :find_one, :find_some, :find_every, :exists?].freeze
+    CLASS_FORCE_SLAVE_METHODS = [:columns, :table_exists?].freeze
 
     def self.extended(base)
       CLASS_SLAVE_METHODS.each { |m| ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(true, base, m) }
+      CLASS_FORCE_SLAVE_METHODS.each { |m| ActiveRecordShards::DefaultSlavePatches.wrap_method_in_on_slave(true, base, m, true) }
 
       base.class_eval do
         include InstanceMethods
 
         class << self
-          alias_method :columns_without_force_slave, :columns
-          alias_method :columns, :columns_with_force_slave
-
-          alias_method :table_exists_without_force_slave?, :table_exists?
-          alias_method :table_exists?, :table_exists_with_force_slave?
-
           alias_method :transaction_without_slave_off, :transaction
           alias_method :transaction, :transaction_with_slave_off
         end
@@ -89,6 +75,10 @@ module ActiveRecordShards
       else
         yield
       end
+    end
+
+    def force_on_slave(&block)
+      on_cx_switch_block(:slave, construct_ro_scope: false, force: true, &block)
     end
 
     module ActiveRelationPatches

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -256,6 +256,22 @@ describe "connection switching" do
     end
   end
 
+  describe ".where.to_sql" do
+    it "doesn't use the master (for escaping)" do
+      with_unsharded_master_unavailable do
+        # This will (on_slave) load the schema for the where statments to bind
+        # with. We could have DefaultSlavePatches wrap load_schema, but this
+        # caused the Phenix test setup gem to have bootstrapping issues.
+        Account.columns
+
+        Account.all.to_sql
+        Account.where('id = 1').to_sql
+        Account.where('id = ?', 1).to_sql
+        Account.where(id: 1).to_sql
+      end
+    end
+  end
+
   describe "ActiveRecord::Base.table_exists?" do
     before do
       ActiveRecord::Base.default_shard = nil


### PR DESCRIPTION
We have boot-time code that needs to grab the `Ticket.to_sql`, where `Ticket` is using soft_deletion with a `where` based `default_scope`. I previously fixed a separate boot-time `Account.where(x: y)` issue in #219, but that was too narrow to handle our case. Problems include:

1. `create_binds` didn't cover every flavor of `where` statement. To cover the rest, I've wrapped any method from https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/sanitization.rb that accesses `connection`
2. `wrap_method_in_on_slave` only worked for `on_slave_by_default` models
3. We didn't handle `Relation#to_sql` at all.

There's a note in the test that we still aren't covering lazy-loaded `load_schemas`. I hit problems with Phenix needing to connect to the slave before the database was created. I'm over my time-box on this change, and it's no worse than it was. We're still covered through any number of eager-schema loading methods.

Possible alternative: So many code paths touch the `connection` exclusively to escape values. We could wrap the connection in a Delegator so that it doesn't eagerly open a connection just run Adapter-specific escaping code. I'm very resistant, because working with a Delegator feels like a 10x complexity multiplier when debugging these gems.

cc @zendesk/database-gem-owners 