### PR TITLE
Remove all deprecated must_* test matchers

### DIFF
--- a/test/migrator_test.rb
+++ b/test/migrator_test.rb
@@ -117,15 +117,15 @@ describe ActiveRecord::Migrator do
 
   describe "#shard_status" do
     it "shows nothing if everything is ok" do
-      _(ActiveRecord::Migrator.shard_status([1])).must_equal([{}, {}])
+      assert_equal [{}, {}], ActiveRecord::Migrator.shard_status([1])
     end
 
     it "shows missing migrations" do
-      _(ActiveRecord::Migrator.shard_status([])).must_equal([{}, { nil => [1], 0 => [1], 1 => [1] }])
+      assert_equal [{}, { nil => [1], 0 => [1], 1 => [1] }], ActiveRecord::Migrator.shard_status([])
     end
 
     it "shows pending migrations" do
-      _(ActiveRecord::Migrator.shard_status([1, 2])).must_equal([{ nil => [2], 0 => [2], 1 => [2] }, {}])
+      assert_equal [{ nil => [2], 0 => [2], 1 => [2] }, {}], ActiveRecord::Migrator.shard_status([1, 2])
     end
   end
 

--- a/test/sql_comments_test.rb
+++ b/test/sql_comments_test.rb
@@ -18,6 +18,6 @@ describe ActiveRecordShards::SqlComments do
 
   it "adds sql comment" do
     comment.execute("foo")
-    _(comment.called).must_equal ["foo /* master */"]
+    assert_equal ["foo /* master */"], comment.called
   end
 end

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -67,14 +67,14 @@ describe "Database rake tasks" do
     it "does not fail when db is missing" do
       rake('db:create')
       rake('db:drop')
-      _(show_databases(config)).wont_include master_name
+      refute_includes(show_databases(config), master_name)
     end
 
     it "fails loudly when unknown error occurs" do
       ActiveRecordShards::Tasks.stubs(:root_connection).raises(ArgumentError)
       out = capture_stderr { rake('db:drop') }
-      _(out).must_include "Couldn't drop "
-      _(out).must_include "test/helper.rb"
+      assert_includes(out, "Couldn't drop ")
+      assert_includes(out, "test/helper.rb")
     end
   end
 
@@ -86,7 +86,7 @@ describe "Database rake tasks" do
     it "passes when there is no pending migrations" do
       ActiveRecord::Migrator.any_instance.stubs(:pending_migrations).returns([])
       out = capture_stderr { rake('db:abort_if_pending_migrations') }
-      out.must_be_empty
+      assert_empty out
     end
 
     it "fails when migrations are pending" do
@@ -98,7 +98,7 @@ describe "Database rake tasks" do
           ""
         end
       end
-      out.must_match(/You have \d+ pending migrations:/)
+      assert_match(/You have \d+ pending migrations:/, out)
     end
   end
 end


### PR DESCRIPTION
I don't particularly like the Minitest assert_* methods, but I like our inconsistent use of matcher methods even less :-)

/cc @zhuravel: ~you may need to rebase #225 – sorry about that.~ Merged #225 and rebased on master.