### PR TITLE
Handle string URL specs handed over to `establish_connection` override for ActiveRecord 4.2

### DIFF
--- a/lib/active_record_shards/connection_specification.rb
+++ b/lib/active_record_shards/connection_specification.rb
@@ -4,7 +4,6 @@ class << ActiveRecord::Base
   remove_method :establish_connection if ActiveRecord::VERSION::MAJOR >= 5
   def establish_connection(spec = ENV["DATABASE_URL"])
     spec ||= ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
-    spec = spec.to_sym if spec.is_a?(String)
     resolver = ActiveRecordShards::ConnectionSpecification::Resolver.new configurations
     spec = resolver.spec(spec)
 


### PR DESCRIPTION
When trying to use this gem for setting up leader-follower DBs in a Rails 4.2 app on Heroku, I noticed that `ENV["DATABASE_URL"]` was getting coerced into a symbol and causing issues with `ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver`.  I was getting this error in particular:
```
ActiveRecord::AdapterNotSpecified: 'adaptertype://blah@server:port/database' database is not configured. Available: ["development", "test", "production", "production_slave"]
```
This error was getting raised here: https://github.com/rails/rails/blob/v4.2.11/activerecord/lib/active_record/connection_adapters/connection_specification.rb#L248.

All versions of ActiveRecord 4.2 [handle parsing string type spec inputs into either URLs or specific DB configs](https://github.com/rails/rails/blob/v4.2.11/activerecord/lib/active_record/connection_adapters/connection_specification.rb#L219-L235), so it makes sense to let it deal with the spec as is for the 4.2 patching.