### PR TITLE
Add #on_primary_db which executes a block in the context of the prima…

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -24,6 +24,10 @@ module ActiveRecordShards
       switch_connection(shard: new_default_shard)
     end
 
+    def on_primary_db(&block)
+      on_shard(nil, &block)
+    end
+
     def on_shard(shard)
       old_options = current_shard_selection.options
       switch_connection(shard: shard) if supports_sharding?


### PR DESCRIPTION
# What does this PR do?

This PR adds `on_primary_db` which executes a block in the context of the primary, non-sharded database.

This is because if you need to re-establish the database connection after a default shard has been set then it will incorrectly set the primary database to the default shard.

The current way around this is to write:

```ruby
ActiveRecord::Base.on_shard(nil) do
  # Code here
end
```

Now we can write it as:

```ruby
ActiveRecord::Base.on_primary_db do
   # Code here...
end
```

## Re-creating the issue

In Rails 6 this can be recreated quite easily in your spec_helper file. Just do this:

```ruby
ActiveRecord::Base.default_shard = 1
ActiveRecord::Migration.maintain_test_schema!

# Now any non-shared models will point to the default shard database. :(
```