### PR TITLE
Update circleci to run rake commands through 'bundle exec'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ test: &test
     - checkout
     - run: sudo apt install default-mysql-client || sudo apt-get update && sudo apt install default-mysql-client
     - run: bundle install
-    - run: rake test
+    - run: bundle exec rake test
 
 jobs:
 
@@ -131,7 +131,7 @@ jobs:
     steps:
       - checkout
       - run: bundle install
-      - run: rake rubocop
+      - run: bundle exec rake rubocop
 
 workflows:
   version: 2


### PR DESCRIPTION
# What does this PR do?

This PR prefixes `rake` commands in the `.circle/config.yml` with `bundle exec`. 

I noticed on PR #233 that rubocop failed due to a rake version mismatch which I believe is related to the underlying host having a different version of rake installed. If I remember correctly, this can occur based on how CircleCI rotates hosts / images since they are shared across all branches for a given project.