### PR TITLE
v3.17.0

### DIFF
--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "3.16.0" do |s|
+Gem::Specification.new "active_record_shards", "3.17.0" do |s|
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"


### PR DESCRIPTION
It’s time for a new minor release: https://github.com/zendesk/active_record_shards/compare/v3.16.0...bquorning.release

The only change worthy of mention is the addition of `ActiveRecord::Base.on_primary_db`.
