### PR TITLE
Make switch_connection backwards compatible

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -162,13 +162,13 @@ module ActiveRecordShards
 
     def switch_connection(options)
       if options.any?
-        if options.key?(:replica)
-          current_shard_selection.on_replica = options[:replica]
-        end
-
         if options.key?(:slave)
           ActiveRecordShards::Deprecation.warn('the `:slave` option should be replaced with `:replica`!')
           options[:replica] ||= options.delete(:slave)
+        end
+
+        if options.key?(:replica)
+          current_shard_selection.on_replica = options[:replica]
         end
 
         if options.key?(:shard)


### PR DESCRIPTION
Passing the `:slave` option wouldn't do anything before; only `:replica` option would work. I believe this was overlooked in #216.