### PR TITLE
Remove respond_to? checks

### DIFF
--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -586,9 +586,7 @@ describe "connection switching" do
         end
 
         it "do exists? on the replica" do
-          if Account.respond_to?(:exists?)
-            assert Account.exists?(1001)
-          end
+          assert Account.exists?(1001)
         end
 
         it "does exists? on the replica with a named scope" do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -18,7 +18,7 @@ require 'phenix'
 RAILS_ENV = "test"
 
 ActiveRecord::Base.logger = Logger.new(__dir__ + "/test.log")
-ActiveSupport.test_order = :sorted if ActiveSupport.respond_to?(:test_order=)
+ActiveSupport.test_order = :sorted
 ActiveSupport::Deprecation.behavior = :raise
 ActiveRecordShards::Deprecation.behavior = :silence
 

--- a/test/models.rb
+++ b/test/models.rb
@@ -12,11 +12,7 @@ end
 class AccountThing < ActiveRecord::Base
   not_sharded
 
-  if respond_to?(:where)
-    scope(:enabled, -> { where(enabled: true) })
-  else
-    named_scope :enabled, conditions: { enabled: true }
-  end
+  scope(:enabled, -> { where(enabled: true) })
 end
 
 class AccountInherited < Account


### PR DESCRIPTION
All these methods are implemented in the lowest version of Rails supported by ARS.