### PR TITLE
More complete implementation of on_replica patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           --health-retries 10
 
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - "2.5"

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed / Fixed
+
+Lots of improvements to the `on_replica_by_default` logic, now covered by an improved test suite. Schema loading should now _always_ happen on the replica databases, and non-mutating queries will should now happen on the replica except when `on_replica_by_default` is not configured.
+
 ## v3.18.0
 
-### Changed
+### Changed / Deprecated
 
-[Deprecation] Adds deprecation warning for all methods containing `master`/`slave` which recommends using the updated `primary`/`replica` methods. The main public methods changed:
+Adds deprecation warning for all methods containing `master`/`slave` which recommends using the updated `primary`/`replica` methods. The main public methods changed:
 
 1. `on_slave` => `on_replica`
 1. `on_master` => `on_primary`

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -32,11 +32,68 @@ ActiveRecord::SchemaDumper.prepend(ActiveRecordShards::SchemaDumperExtension)
 case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
 when '4.2'
   require 'active_record_shards/patches-4-2'
-when '5.0', '5.1', '5.2'
-  :ok
+
+  # https://github.com/rails/rails/blob/v4.2.11.3/activerecord/lib/active_record/associations/association.rb#L97
+  ActiveRecord::Associations::Association.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationAssociationScopePatch)
+
+  # https://github.com/rails/rails/blob/v4.2.11.3/activerecord/lib/active_record/associations/singular_association.rb#L44-L53
+  ActiveRecord::Associations::SingularAssociation.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationGetRecordsPatch)
+
+  # https://github.com/rails/rails/blob/v4.2.11.3/activerecord/lib/active_record/associations/collection_association.rb#L447-L456
+  ActiveRecord::Associations::CollectionAssociation.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationGetRecordsPatch)
+
+  # https://github.com/rails/rails/blob/v4.2.11.3/activerecord/lib/active_record/associations/preloader/association.rb#L89
+  ActiveRecord::Associations::Preloader::Association.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsPreloaderAssociationAssociatedRecordsByOwnerPatch)
+when '5.0'
+  # https://github.com/rails/rails/blob/v5.0.7/activerecord/lib/active_record/associations/association.rb#L97
+  ActiveRecord::Associations::Association.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationAssociationScopePatch)
+
+  # https://github.com/rails/rails/blob/v5.0.7/activerecord/lib/active_record/associations/singular_association.rb#L56-L65
+  ActiveRecord::Associations::SingularAssociation.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationGetRecordsPatch)
+
+  # https://github.com/rails/rails/blob/v5.0.7/activerecord/lib/active_record/associations/collection_association.rb#L442-L451
+  ActiveRecord::Associations::CollectionAssociation.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationGetRecordsPatch)
+
+  # https://github.com/rails/rails/blob/v5.0.7/activerecord/lib/active_record/associations/preloader/association.rb#L120
+  ActiveRecord::Associations::Preloader::Association.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsPreloaderAssociationLoadRecordsPatch)
+when '5.1'
+  # https://github.com/rails/rails/blob/v5.1.7/activerecord/lib/active_record/associations/association.rb#L97
+  ActiveRecord::Associations::Association.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationAssociationScopePatch)
+
+  # https://github.com/rails/rails/blob/v5.1.7/activerecord/lib/active_record/associations/singular_association.rb#L41
+  ActiveRecord::Associations::SingularAssociation.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationFindTargetPatch)
+
+  # https://github.com/rails/rails/blob/v5.1.7/activerecord/lib/active_record/associations/collection_association.rb#L305
+  ActiveRecord::Associations::CollectionAssociation.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationFindTargetPatch)
+
+  # https://github.com/rails/rails/blob/v5.1.7/activerecord/lib/active_record/associations/preloader/association.rb#L120
+  ActiveRecord::Associations::Preloader::Association.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsPreloaderAssociationLoadRecordsPatch)
+when '5.2'
+  # https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/relation.rb#L530
+  # But the #exec_queries method also calls #connection, and I don't know if we should patch that one, too...
+  ActiveRecord::Relation.prepend(ActiveRecordShards::DefaultReplicaPatches::Rails52RelationPatches)
+
+  # https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/associations/singular_association.rb#L42
+  ActiveRecord::Associations::SingularAssociation.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationFindTargetPatch)
+
+  # https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/associations/collection_association.rb#L308
+  ActiveRecord::Associations::CollectionAssociation.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationFindTargetPatch)
+
+  # https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/associations/preloader/association.rb#L96
+  ActiveRecord::Associations::Preloader::Association.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsPreloaderAssociationLoadRecordsPatch)
 when '6.0'
-  ActiveRecord::TypeCaster::Connection.prepend(ActiveRecordShards::DefaultReplicaPatches::TypeCasterConnectionPatches)
-  ActiveRecord::Schema.prepend(ActiveRecordShards::DefaultReplicaPatches::SchemaPatches)
+  # https://github.com/rails/rails/blob/v6.0.4/activerecord/lib/active_record/type_caster/connection.rb#L28
+  ActiveRecord::TypeCaster::Connection.prepend(ActiveRecordShards::DefaultReplicaPatches::TypeCasterConnectionConnectionPatch)
+
+  # https://github.com/rails/rails/blob/v6.0.4/activerecord/lib/active_record/schema.rb#L53-L54
+  ActiveRecord::Schema.prepend(ActiveRecordShards::DefaultReplicaPatches::SchemaDefinePatch)
+
+  # https://github.com/rails/rails/blob/v6.0.4/activerecord/lib/active_record/relation.rb#L739
+  # But the #exec_queries and #compute_cache_version methods also call #connection, and I don't know if we should patch those, too...
+  ActiveRecord::Relation.prepend(ActiveRecordShards::DefaultReplicaPatches::Rails52RelationPatches)
+
+  # https://github.com/rails/rails/blob/v6.0.4/activerecord/lib/active_record/associations/association.rb#L213
+  ActiveRecord::Associations::Association.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsAssociationFindTargetPatch)
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"
 end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -502,8 +502,6 @@ describe "connection switching" do
         end
 
         it "be marked as read only" do
-          skip("Readonly scope on finder method is complicated on Rails 4.2")
-
           assert(@model.readonly?)
         end
 

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -522,7 +522,7 @@ describe "connection switching" do
             assert User.on_replica_by_default?
             assert User.finder_needs_type_condition?
 
-            User.send(:reset_column_information)
+            User.reset_column_information
             User.columns_hash
           ensure
             Person.on_replica_by_default = false

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -519,12 +519,16 @@ describe "connection switching" do
       describe "a inherited model without cached columns hash" do
         # before columns -> with_scope -> type-condition -> columns == loop
         it "not loop when on replica by default" do
-          Person.on_replica_by_default = true
-          assert User.on_replica_by_default?
-          assert User.finder_needs_type_condition?
+          begin
+            Person.on_replica_by_default = true
+            assert User.on_replica_by_default?
+            assert User.finder_needs_type_condition?
 
-          User.instance_variable_set(:@columns_hash, nil)
-          User.columns_hash
+            User.send(:reset_column_information)
+            User.columns_hash
+          ensure
+            Person.on_replica_by_default = false
+          end
         end
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -123,6 +123,7 @@ module SpecHelpers
   # Verifies that a block of code is not using the unsharded primary by pausing
   # the TCP proxy between Ruby and MySQL.
   def with_unsharded_primary_unavailable
+    ActiveRecord::Base.connection_handler.clear_all_connections!
     @@unsharded_primary_proxy.pause do
       yield
     end
@@ -131,6 +132,7 @@ module SpecHelpers
   # Verifies that a block of code is not using the sharded primaries by pausing
   # the TCP proxies between Ruby and MySQL.
   def with_sharded_primaries_unavailable
+    ActiveRecord::Base.connection_handler.clear_all_connections!
     @@shard_1_primary_proxy.pause do
       @@shard_2_primary_proxy.pause do
         yield

--- a/test/models.rb
+++ b/test/models.rb
@@ -28,4 +28,7 @@ class Person < ActiveRecord::Base
 end
 
 class User < Person
+  # Makes `User.new` a bit more complicated. Don't change without changing the
+  # corresponding tests.
+  default_scope { where(type: 'User') }
 end

--- a/test/on_replica_by_default_test.rb
+++ b/test/on_replica_by_default_test.rb
@@ -48,16 +48,12 @@ describe ".on_replica_by_default" do
     end
 
     it "fails for the unsharded DB" do
-      skip "This test is very slow"
-
       with_all_primaries_unavailable do
         assert_raises { Account.on_primary.connection }
       end
     end
 
     it "fails for the sharded DB" do
-      skip "This test is very slow"
-
       with_all_primaries_unavailable do
         assert_raises { Ticket.on_primary.connection }
       end

--- a/test/on_replica_by_default_test.rb
+++ b/test/on_replica_by_default_test.rb
@@ -79,6 +79,13 @@ describe ".on_replica_by_default" do
     end
   end
 
+  it "executes `find_by` on the replica" do
+    with_all_primaries_unavailable do
+      account = Account.find_by(id: 1000)
+      assert_equal "Replica account", account.name
+    end
+  end
+
   it "executes `count` on the replica" do
     with_all_primaries_unavailable do
       count = Account.count
@@ -142,8 +149,114 @@ describe ".on_replica_by_default" do
     end
   end
 
+  it "executes `first` on association on the replica" do
+    with_all_primaries_unavailable do
+      account = Account.find(1001)
+      person = account.people.first
+      assert_equal "Replica person", person.name
+    end
+  end
+
+  it "executes `map` on preloaded relation on the primary" do
+    Ticket.on_shard(1) do
+      Ticket.connection.execute(
+        "INSERT INTO tickets (id, title, account_id, created_at, updated_at) VALUES (50000, 'Primary ticket', 1001, NOW(), NOW())"
+      )
+      Ticket.on_replica.connection.execute(
+        "INSERT INTO tickets (id, title, account_id, created_at, updated_at) VALUES (50001, 'Replica ticket', 1001, NOW(), NOW())"
+      )
+
+      with_unsharded_primary_unavailable do
+        ticket_rel = Ticket.preload(:account).where(id: 50000)
+        ticket_titles = ticket_rel.map(&:title)
+        assert_equal ["Primary ticket"], ticket_titles
+      end
+    end
+  end
+
+  it "executes `all` on association on the replica" do
+    with_all_primaries_unavailable do
+      account = Account.find(1001)
+      all_people = account.people.all
+      assert_equal ["Replica person"], all_people.map(&:name)
+    end
+  end
+
+  it "executes `count` on association on the replica" do
+    Person.on_replica.connection.execute(
+      "INSERT INTO people(id, name) VALUES (30, 'Replica person 2')"
+    )
+    Account.on_replica.connection.execute(
+      "INSERT INTO account_people(account_id, person_id) VALUES (1001, 30)"
+    )
+
+    with_all_primaries_unavailable do
+      account = Account.find(1001)
+      count = account.people.count
+      assert_equal 2, count
+    end
+  end
+
+  it "can call preload from sharded model to unsharded model" do
+    Ticket.on_shard(1) do
+      Ticket.connection.execute(
+        "INSERT INTO tickets (id, title, account_id, created_at, updated_at) VALUES (50000, 'Primary ticket', 1000, NOW(), NOW())"
+      )
+      Ticket.on_replica.connection.execute(
+        "INSERT INTO tickets (id, title, account_id, created_at, updated_at) VALUES (50001, 'Replica ticket', 1001, NOW(), NOW())"
+      )
+    end
+
+    begin
+      Ticket.on_replica_by_default = true
+
+      Ticket.on_shard(1) do
+        with_all_primaries_unavailable do
+          tickets = Ticket.preload(:account)
+          ticket = tickets.first
+
+          assert_equal "Replica ticket", ticket.title
+          assert_equal "Replica account 2", ticket.account.name
+        end
+      end
+    ensure
+      Ticket.on_replica_by_default = false
+    end
+  end
+
+  it "can handle association from sharded model to unsharded model" do
+    Ticket.on_shard(1) do
+      Ticket.connection.execute(
+        "INSERT INTO tickets (id, title, account_id, created_at, updated_at) VALUES (50000, 'Primary ticket', 1000, NOW(), NOW())"
+      )
+      Ticket.on_replica.connection.execute(
+        "INSERT INTO tickets (id, title, account_id, created_at, updated_at) VALUES (50001, 'Replica ticket', 1001, NOW(), NOW())"
+      )
+    end
+
+    begin
+      Ticket.on_replica_by_default = true
+
+      Ticket.on_shard(1) do
+        with_all_primaries_unavailable do
+          ticket = Ticket.find(50001)
+          account_name = ticket.account.name
+          assert_equal "Replica account 2", account_name
+        end
+      end
+    ensure
+      Ticket.on_replica_by_default = false
+    end
+  end
+
+  it "can instantiate a new record whose model defines an ordered default_scope" do
+    with_all_primaries_unavailable do
+      User.new
+    end
+  end
+
   it "loads schema from replica" do
-    Account.send(:reset_column_information)
+    Account.reset_column_information
 
     # Verify that the schema hasn't been loaded yet
     assert_nil Account.instance_variable_get :@columns


### PR DESCRIPTION
Even when declaring an ActiveRecord model as `on_replica_by_default`, some queries are still being performed on the primary database connection. Some methods will just open a connection to the primary (e.g. when using the connection _adapter_ for escaping an SQL string, or type casting based on the schema), but not execute a query.

This PR improves the test cases by closing existing connections before pausing the test TCP proxy. That change revealed a number of cases where a new primary DB connection was being made, and all of them should be solved in this pull request.

#### ~Help!~

~I am seeing some tests fail with `stream closed in another thread (IOError)` from inside the `TCPProxy` class. The failures are flaky, and a rerun will often make them pass. But it’s really hard to get an all-green CI run.~

Update: The problem may be a bug, [fixed in Ruby 2.6+](https://github.com/ruby/ruby/commit/645f7fbd4ec0199c6266df19ad82d99bdd8553a8). I’ve added a workaround for Ruby 2.5.