### PR TITLE
Test on_replica_by_default tests with disabled access to primary databases

### DIFF
--- a/test/database.yml
+++ b/test/database.yml
@@ -22,17 +22,27 @@ test_replica:
   <<: *MYSQL
   database: ars_test_replica
 
+# We connect to this sharded primary database on a different port, via a proxy,
+# so we can make the connection unavailable when testing on_replica_by_default
+# behavior.
 test_shard_0:
   <<: *MYSQL
   database: ars_test_shard0
+  host: 127.0.0.1
+  port: 13307
 
 test_shard_0_replica:
   <<: *MYSQL
   database: ars_test_shard0_replica
 
+# We connect to this sharded primary database on a different port, via a proxy,
+# so we can make the connection unavailable when testing on_replica_by_default
+# behavior.
 test_shard_1:
   <<: *MYSQL
   database: ars_test_shard1
+  host: 127.0.0.1
+  port: 13308
 
 test_shard_1_replica:
   <<: *MYSQL

--- a/test/on_replica_by_default_test.rb
+++ b/test/on_replica_by_default_test.rb
@@ -55,29 +55,40 @@ describe ".on_replica_by_default" do
   end
 
   it "executes `find` on the replica" do
-    account = Account.find(1000)
-    assert_equal "Replica account", account.name
+    with_all_primaries_unavailable do
+      account = Account.find(1000)
+      assert_equal "Replica account", account.name
+    end
   end
 
   it "executes `count` on the replica" do
-    count = Account.count
-    assert_equal 2, count
+    with_all_primaries_unavailable do
+      count = Account.count
+      assert_equal 2, count
+    end
   end
 
   it "executes `reload` on the replica" do
-    account = Account.find(1000)
-    assert_equal "Replica account", account.reload.name
+    with_all_primaries_unavailable do
+      account = Account.find(1000)
+      assert_equal "Replica account", account.reload.name
+    end
   end
 
   it "executes `exists?` on the replica" do
-    assert Account.exists?(1001)
+    with_all_primaries_unavailable do
+      assert Account.exists?(1001)
+    end
   end
 
   it "executes `exists?` on the replica with a named scope" do
     AccountThing.on_replica_by_default = true
     AccountThing.on_replica.connection.execute("INSERT INTO account_things (id, account_id) VALUES (123125, 1000)")
 
-    assert AccountThing.enabled.exists?(123125)
+    with_all_primaries_unavailable do
+      assert AccountThing.enabled.exists?(123125)
+    end
+
     AccountThing.on_replica_by_default = false
   end
 
@@ -86,45 +97,62 @@ describe ".on_replica_by_default" do
     AccountThing.on_replica.connection.execute("INSERT INTO account_things (id, account_id) VALUES (123123, 1000)")
     AccountThing.on_replica.connection.execute("INSERT INTO account_things (id, account_id) VALUES (123124, 1000)")
 
-    assert_equal 2, Account.find(1000).account_things.count
+    with_all_primaries_unavailable do
+      assert_equal 2, Account.find(1000).account_things.count
+    end
+
     AccountThing.on_replica_by_default = false
   end
 
   it "`includes` things via has_and_belongs_to_many associations correctly" do
-    a = Account.where(id: 1001).includes(:people).first
-    refute_empty(a.people)
-    assert_equal "Replica person", a.people.first.name
+    with_all_primaries_unavailable do
+      a = Account.where(id: 1001).includes(:people).first
+      refute_empty(a.people)
+      assert_equal "Replica person", a.people.first.name
+    end
   end
 
   it "sets up has_and_belongs_to_many sharded-ness correctly" do
-    refute Account.const_get(:HABTM_People).is_sharded?
+    with_all_primaries_unavailable do
+      refute Account.const_get(:HABTM_People).is_sharded?
+    end
   end
 
   it "executes `pluck` on the replica" do
-    assert_equal ["Replica account", "Replica account 2"], Account.pluck(:name)
+    with_all_primaries_unavailable do
+      assert_equal ["Replica account", "Replica account 2"], Account.pluck(:name)
+    end
   end
 
   describe "joins" do
     it "supports implicit joins" do
-      accounts = Account.includes(:account_things).references(:account_things)
-      account_names = accounts.order("account_things.id").map(&:name).sort
-      assert_equal ["Replica account", "Replica account 2"], account_names
+      with_all_primaries_unavailable do
+        accounts = Account.includes(:account_things).references(:account_things)
+        account_names = accounts.order("account_things.id").map(&:name).sort
+        assert_equal ["Replica account", "Replica account 2"], account_names
+      end
     end
 
     it "supports explicit joins" do
-      accounts = Account.joins("LEFT OUTER JOIN account_things ON account_things.account_id = accounts.id")
-      account_names = accounts.map(&:name).sort
-      assert_equal ["Replica account", "Replica account 2"], account_names
+      with_all_primaries_unavailable do
+        accounts = Account.joins("LEFT OUTER JOIN account_things ON account_things.account_id = accounts.id")
+        account_names = accounts.map(&:name).sort
+        assert_equal ["Replica account", "Replica account 2"], account_names
+      end
     end
 
     it "does not support implicit joins between an unsharded and a sharded table" do
-      accounts = Account.includes(:tickets).references(:tickets).order("tickets.id")
-      assert_raises(ActiveRecord::StatementInvalid) { accounts.first }
+      with_all_primaries_unavailable do
+        accounts = Account.includes(:tickets).references(:tickets).order("tickets.id")
+        assert_raises(ActiveRecord::StatementInvalid) { accounts.first }
+      end
     end
 
     it "does not support explicit joins between an unsharded and a sharded table" do
-      accounts = Account.joins("LEFT OUTER JOIN tickets ON tickets.account_id = accounts.id")
-      assert_raises(ActiveRecord::StatementInvalid) { accounts.first }
+      with_all_primaries_unavailable do
+        accounts = Account.joins("LEFT OUTER JOIN tickets ON tickets.account_id = accounts.id")
+        assert_raises(ActiveRecord::StatementInvalid) { accounts.first }
+      end
     end
   end
 


### PR DESCRIPTION
When testing that `.on_replica_by_default` works as expected, let's make the primary databases unavailable.

This PR adds methods to temporarily disable access to the sharded primary databases.

It seems that we don't always read the schema from a replica database, even if on_replica_by_default is set on a model. I'll investigate that in a later pull request.