### PR TITLE
TCP proxy improvements

### DIFF
--- a/test/support/tcp_proxy.rb
+++ b/test/support/tcp_proxy.rb
@@ -43,7 +43,7 @@ class TCPProxy
             begin
               responding_socket = TCPSocket.new(remote_host, remote_port)
 
-              requests = Thread.new { forward(requesting_socket, responding_socket) }
+              requests = Thread.new { forward(requesting_socket, responding_socket, pause_behavior: :raise) }
               requests.abort_on_exception = true
 
               responses = Thread.new { forward(responding_socket, requesting_socket) }
@@ -78,18 +78,19 @@ class TCPProxy
 
   attr_reader :remote_host, :remote_port, :local_port
 
-  def forward(src, dst)
+  def forward(src, dst, pause_behavior: :ignore)
     zero_counter = 0
     loop do
+      data = src.recv(1024)
       if enabled?
-        data = src.recv(1024)
-
         if data.empty?
           zero_counter += 1
           return if zero_counter >= 5
         else
           dst.send(data, 0)
         end
+      elsif pause_behavior == :raise
+        raise "TCPProxy received a request while paused"
       else
         sleep 0.2
       end


### PR DESCRIPTION
After #247 introduced a TCP Proxy to help with testing, I ran into a few problems which are fixed in this PR:

- Start new thread when accepting a connection
  The TCPProxy would previously only accept one incoming connection, and then block until the client or the server closed the connection on either end. That doesn’t play well when the connection is not being closed before Phenix fires off a `mysql` shell command which requires accepting a *new* connection.
- Don't let disabled proxy hang indefinitely
  If the TCPProxy receives a request while paused, we would previously do nothing – just wait 0.2 seconds and then read some more from the socket, ad inifitum. That meant that if our code under test would query the wrong database (e.g. a primary DB, via a paused proxy), the specs would hang indefinitely.
  In this PR, the implementation is changed for the “requests” thread, so that if our tests makes a query (via `Mysql2::Client` or the `mysql` shell command etc.), an exception is raised and the test will fail immediately. The behavior of the “responses” thread is unchanged.
