### PR TITLE
Remove Rails 4.0 specific code

### DIFF
--- a/lib/active_record_shards/default_replica_patches.rb
+++ b/lib/active_record_shards/default_replica_patches.rb
@@ -107,10 +107,6 @@ module ActiveRecordShards
           alias_method :transaction, :transaction_with_replica_off
         end
       end
-      if ActiveRecord::Associations.const_defined?(:HasAndBelongsToManyAssociation)
-        ActiveRecordShards::DefaultReplicaPatches.wrap_method_in_on_replica(false, ActiveRecord::Associations::HasAndBelongsToManyAssociation, :construct_sql)
-        ActiveRecordShards::DefaultReplicaPatches.wrap_method_in_on_replica(false, ActiveRecord::Associations::HasAndBelongsToManyAssociation, :construct_find_options!)
-      end
     end
 
     def on_replica_unless_tx


### PR DESCRIPTION
The `ActiveRecord::Associations::HasAndBelongsToManyAssociation` class was removed right before Rails 4.1, in https://github.com/rails/rails/commit/5864b9a894a784aea3500d7b72ab78b6f.

Do we need a changelog entry?