### PR TITLE
Fix schema loading

### DIFF
--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -36,6 +36,7 @@ when '5.0', '5.1', '5.2'
   :ok
 when '6.0'
   ActiveRecord::TypeCaster::Connection.prepend(ActiveRecordShards::DefaultReplicaPatches::TypeCasterConnectionPatches)
+  ActiveRecord::Schema.prepend(ActiveRecordShards::DefaultReplicaPatches::SchemaPatches)
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"
 end

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -64,8 +64,6 @@ ActiveRecordShards::Deprecation.deprecate_methods(
 
 ActiveRecordShards::Deprecation.deprecate_methods(
   ActiveRecordShards::DefaultReplicaPatches,
-  columns_with_force_slave: :columns_with_force_replica,
-  table_exists_with_force_slave?: :table_exists_with_force_replica?,
   transaction_with_slave_off: :transaction_with_replica_off,
   on_slave_unless_tx: :on_replica_unless_tx
 )

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -32,8 +32,10 @@ ActiveRecord::SchemaDumper.prepend(ActiveRecordShards::SchemaDumperExtension)
 case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
 when '4.2'
   require 'active_record_shards/patches-4-2'
-when '5.0', '5.1', '5.2', '6.0'
+when '5.0', '5.1', '5.2'
   :ok
+when '6.0'
+  ActiveRecord::TypeCaster::Connection.prepend(ActiveRecordShards::DefaultReplicaPatches::TypeCasterConnectionPatches)
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"
 end

--- a/lib/active_record_shards/default_replica_patches.rb
+++ b/lib/active_record_shards/default_replica_patches.rb
@@ -157,5 +157,17 @@ module ActiveRecordShards
         model
       end
     end
+
+    module TypeCasterConnectionPatches
+      def connection
+        return super if Thread.current[:_active_record_shards_in_tx]
+
+        if @klass.on_replica_by_default?
+          @klass.on_replica.connection
+        else
+          super
+        end
+      end
+    end
   end
 end

--- a/lib/active_record_shards/default_replica_patches.rb
+++ b/lib/active_record_shards/default_replica_patches.rb
@@ -66,7 +66,8 @@ module ActiveRecordShards
       :find_by_sql,
       :find_every,
       :find_one,
-      :find_some
+      :find_some,
+      :get_primary_key
     ].freeze
 
     CLASS_FORCE_REPLICA_METHODS = [

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -295,11 +295,6 @@ describe "connection switching" do
   describe ".where.to_sql" do
     it "doesn't use the primary (for escaping)" do
       with_unsharded_primary_unavailable do
-        # This will (on_replica) load the schema for the where statments to bind
-        # with. We could have DefaultReplicaPatches wrap load_schema, but this
-        # caused the Phenix test setup gem to have bootstrapping issues.
-        Account.columns
-
         Account.all.to_sql
         Account.where('id = 1').to_sql
         Account.where('id = ?', 1).to_sql

--- a/test/support/tcp_proxy.rb
+++ b/test/support/tcp_proxy.rb
@@ -93,7 +93,8 @@ class TCPProxy
       elsif disabled? && pause_behavior == :return
         clean_data = data.gsub(/[^\w. ]/, '').strip
 
-        if schema_query?(clean_data)
+        if ActiveRecord::VERSION::MAJOR == 4 && schema_query?(clean_data)
+          warn "Rails 4.x performed #{clean_data} on a primary database."
           dst.send(data, 0)
         else
           warn "TCPProxy received a request while paused: `#{clean_data}`"
@@ -105,11 +106,8 @@ class TCPProxy
     end
   end
 
-  # FIXME: We should not allow fetching schema information from the primary DB.
   def schema_query?(data)
-    data.include?("information_schema.tables") ||
-      data.include?("information_schema.statistics") ||
-      data.include?("information_schema.key_column_usage") ||
+    data.include?("information_schema.key_column_usage") ||
       data.include?("SHOW TABLES") ||
       data.include?("SHOW CREATE TABLE") ||
       data.include?("SHOW FULL FIELDS FROM")


### PR DESCRIPTION
This PR cleans up the existing schema loading method patches (for `#columns` and `#table_exists?`) a bit, and add patches for the Rails 5+ `#load_schema!` method. Also patches the `#get_primary_key` method, which is used for all versions of Rails.

These changes caused our tests to fail when running against Rails 6.0, because of [this change in Rails](https://github.com/rails/rails/pull/36439). We work around it by patching the `ActiveRecord::Schema#define` method to make automatic replica switching disabled while a migration is running.