### PR TITLE
Add shard information to debug SQL comments

### DIFF
--- a/lib/active_record_shards/sql_comments.rb
+++ b/lib/active_record_shards/sql_comments.rb
@@ -3,8 +3,11 @@ module ActiveRecordShards
   module SqlComments
     module Methods
       def execute(query, name = nil)
+        shard = ActiveRecord::Base.current_shard_selection.shard
+        shard_text = shard ? "shard #{shard}" : 'unsharded'
         replica = ActiveRecord::Base.current_shard_selection.on_replica?
-        query += " /* #{replica ? 'replica' : 'primary'} */"
+        replica_text = replica ? 'replica' : 'primary'
+        query = "/* #{shard_text} #{replica_text} */ " + query
         super(query, name)
       end
     end

--- a/test/active_record_shards/sql_comments_test.rb
+++ b/test/active_record_shards/sql_comments_test.rb
@@ -19,6 +19,6 @@ describe ActiveRecordShards::SqlComments do
 
   it "adds sql comment" do
     comment.execute("foo")
-    assert_equal ["foo /* primary */"], comment.called
+    assert_equal ["/* unsharded primary */ foo"], comment.called
   end
 end

--- a/test/support/tcp_proxy.rb
+++ b/test/support/tcp_proxy.rb
@@ -91,7 +91,7 @@ class TCPProxy
           dst.send(data, 0)
         end
       elsif disabled? && pause_behavior == :return
-        clean_data = data.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
+        clean_data = data.gsub(/[^\w. ]/, '').strip
 
         if schema_query?(clean_data)
           dst.send(data, 0)
@@ -108,6 +108,10 @@ class TCPProxy
   # FIXME: We should not allow fetching schema information from the primary DB.
   def schema_query?(data)
     data.include?("information_schema.tables") ||
+      data.include?("information_schema.statistics") ||
+      data.include?("information_schema.key_column_usage") ||
+      data.include?("SHOW TABLES") ||
+      data.include?("SHOW CREATE TABLE") ||
       data.include?("SHOW FULL FIELDS FROM")
   end
 


### PR DESCRIPTION
When using the SQL comments to help debugging e.g. why tests are failing, it’s nice to also have the shard information available.

Before e.g. `"SELECT * FROM foo /* primary */"`
After e.g. `"/* shard 2 primary */ SELECT * FROM foo"`

2nd commit fixes some test failures that should have been covered by 6f958de9773f9f3c2235fd611cf6c44c5e087954 but were only revealed when running the suite multiple times (load order issues).