### PR TITLE
Allow thread variable to prevent replica switch

### DIFF
--- a/lib/active_record_shards/default_replica_patches.rb
+++ b/lib/active_record_shards/default_replica_patches.rb
@@ -119,7 +119,11 @@ module ActiveRecordShards
     alias_method :on_slave_unless_tx, :on_replica_unless_tx
 
     def force_on_replica(&block)
-      on_cx_switch_block(:replica, construct_ro_scope: false, force: true, &block)
+      if !Thread.current[:_active_record_shards_replica_off]
+        on_cx_switch_block(:replica, construct_ro_scope: false, force: true, &block)
+      else
+        yield
+      end
     end
 
     module ActiveRelationPatches


### PR DESCRIPTION
If `Thread[:_active_record_shards_replica_off]` is set, don't switch to replica even inside the `#force_on_replica` method.

E.g. when running migrations, we don't want *under any circumstances* to switch operation to another database. The main problem is that when schema loading is finally fixed (to always use a replica DB), the wrong schema will be used by the migration code to determine whether all meta tables are present on a database.