### PR TITLE
Disable Rails 5.1 + 5.2 tests with Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
             gemfile: rails4.2
           - ruby-version: "2.7"
             gemfile: rails5.0
+          - ruby-version: "2.7"
+            gemfile: rails5.1
+          - ruby-version: "2.7"
+            gemfile: rails5.2
         include:
           - ruby-version: "2.7"
             gemfile: rails6.0


### PR DESCRIPTION
Older versions of Rails cause our tests to emit warnings, which are sometimes captured in tests expecting STDERR to be empty.

Example [one](https://github.com/zendesk/active_record_shards/pull/257/checks?check_run_id=2941445358) and [two](https://github.com/zendesk/active_record_shards/pull/245/checks?check_run_id=2941454668) failing with

```
  1) Failure:
Database rake tasks::abort_if_pending_migrations#test_0001_passes when there is no pending migrations [/home/runner/work/active_record_shards/active_record_shards/test/tasks_test.rb:102]:
Expected "/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:872: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call\n/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/schema_definitions.rb:219: warning: The called method `initialize' is defined here\n/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/schema_migration.rb:28: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call\n/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/schema_definitions.rb:187: warning: The called method `string' is defined here\n/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/schema_definitions.rb:322: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call\n/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/mysql/schema_definitions.rb:62: warning: The called method `new_column_definition' is defined here\n/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/schema_creation.rb:17: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call\n/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:513: warning: The called method `type_to_sql' is defined here\n/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/internal_metadata.rb:35: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call\n/home/runner/work/active_record_shards/active_record_shards/vendor/bundle/ruby/2.7.0/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/schema_definitions.rb:187: warning: The called method `string' is defined here\n" to be empty.
```
readable version:
```
Expected [2578 characters long string] to be empty.
```