### PR TITLE
Bump to v3.19.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v3.19.0
+
 ### Changed / Fixed
 
 Lots of improvements to the `on_replica_by_default` logic, now covered by an improved test suite. Schema loading should now _always_ happen on the replica databases, and non-mutating queries will should now happen on the replica except when `on_replica_by_default` is not configured.

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "3.18.0" do |s|
+Gem::Specification.new "active_record_shards", "3.19.0" do |s|
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"


### PR DESCRIPTION
Lots of improvements to the `on_replica_by_default` logic, now covered
by an improved test suite. Schema loading should now _always_ happen on
the replica databases, and non-mutating queries will should now happen
on the replica except when `on_replica_by_default` is not configured.