### PR TITLE
Fix NotImplementedError from ActiveRecordBase configurations

### DIFF
--- a/lib/active_record_shards/connection_switcher-5-0.rb
+++ b/lib/active_record_shards/connection_switcher-5-0.rb
@@ -4,7 +4,7 @@ module ActiveRecordShards
       name = current_shard_selection.resolve_connection_name(sharded: is_sharded?, configurations: configurations)
 
       unless configurations[name] || name == "primary"
-        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.keys.inspect})"
+        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.to_h.keys.inspect})"
       end
 
       name

--- a/lib/active_record_shards/connection_switcher-5-1.rb
+++ b/lib/active_record_shards/connection_switcher-5-1.rb
@@ -4,7 +4,7 @@ module ActiveRecordShards
       name = current_shard_selection.resolve_connection_name(sharded: is_sharded?, configurations: configurations)
 
       unless configurations[name] || name == "primary"
-        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.keys.inspect})"
+        raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.to_h.keys.inspect})"
       end
 
       name

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -154,7 +154,7 @@ module ActiveRecordShards
 
     def shard_names
       unless config = configurations[shard_env]
-        raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.keys.inspect})"
+        raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.to_h.keys.inspect})"
       end
       unless config.fetch(SHARD_NAMES_CONFIG_KEY, []).all? { |shard_name| shard_name.is_a?(Integer) }
         raise "All shard names must be integers: #{config[SHARD_NAMES_CONFIG_KEY].inspect}."
@@ -173,7 +173,7 @@ module ActiveRecordShards
 
         if options.key?(:shard)
           unless configurations[shard_env]
-            raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.keys.inspect})"
+            raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.to_h.keys.inspect})"
           end
 
           current_shard_selection.shard = options[:shard]


### PR DESCRIPTION
ActiveRecord::Base.configurations used to return a hash before Rails 6 but now
returns an object of configurations. We can return a hash like we used to expect
by calling .to_h on the object. For Rails < 6 .to_h will return the hash unchanged.


Relevant Rails PR: https://github.com/rails/rails/pull/33637