### PR TITLE
Add compatibility with Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - "2.5"
           - "2.6"
           - "2.7"
+          - "3.0"
         gemfile:
           - rails5.0
           - rails5.1
@@ -37,6 +38,14 @@ jobs:
           - ruby-version: "2.7"
             gemfile: rails5.1
           - ruby-version: "2.7"
+            gemfile: rails5.2
+          - ruby-version: "3.0"
+            gemfile: rails4.2
+          - ruby-version: "3.0"
+            gemfile: rails5.0
+          - ruby-version: "3.0"
+            gemfile: rails5.1
+          - ruby-version: "3.0"
             gemfile: rails5.2
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
@@ -56,6 +65,6 @@ jobs:
       - name: Set up Ruby
         uses: zendesk/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.0"
           bundler-cache: true
       - run: bundle exec rake rubocop

--- a/lib/active_record_shards/association_collection_connection_selection.rb
+++ b/lib/active_record_shards/association_collection_connection_selection.rb
@@ -36,6 +36,7 @@ module ActiveRecordShards
         reflection = @association_collection.proxy_association.reflection
         reflection.klass.on_cx_switch_block(@which) { @association_collection.send(method, *args, &block) }
       end
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
   end
 end

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -201,6 +201,7 @@ module ActiveRecordShards
       def method_missing(method, *args, &block) # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing
         @target.on_primary_or_replica(@which) { @target.send(method, *args, &block) }
       end
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
   end
 end

--- a/lib/active_record_shards/default_replica_patches.rb
+++ b/lib/active_record_shards/default_replica_patches.rb
@@ -22,7 +22,7 @@ module ActiveRecordShards
               #{method}_without_default_replica#{punctuation}(*args, &block)
             end
           end
-
+          ruby2_keywords(:#{method}_with_default_replica#{punctuation}) if respond_to?(:ruby2_keywords, true)
           alias_method :#{method}_without_default_replica#{punctuation}, :#{method}#{punctuation}
           alias_method :#{method}#{punctuation}, :#{method}_with_default_replica#{punctuation}
         #{class_method ? 'end' : ''}
@@ -42,6 +42,7 @@ module ActiveRecordShards
         transaction_without_replica_off(*args, &block)
       end
     end
+    ruby2_keywords(:transaction_with_replica_off) if respond_to?(:ruby2_keywords, true)
 
     module InstanceMethods
       def on_replica_unless_tx

--- a/lib/active_record_shards/migration.rb
+++ b/lib/active_record_shards/migration.rb
@@ -22,6 +22,7 @@ module ActiveRecord
         ActiveRecord::InternalMetadata.create_table
       end
     end
+    ruby2_keywords(:initialize_with_sharding) if respond_to?(:ruby2_keywords, true)
     alias_method :initialize_without_sharding, :initialize
     alias_method :initialize, :initialize_with_sharding
 

--- a/lib/active_record_shards/shard_support.rb
+++ b/lib/active_record_shards/shard_support.rb
@@ -30,6 +30,7 @@ module ActiveRecordShards
       end
       raise exception
     end
+    ruby2_keywords(:find) if respond_to?(:ruby2_keywords, true)
 
     def count
       enum.inject(0) { |accum, _shard| @scope.clone.count + accum }


### PR DESCRIPTION
The main issue is handling delegation of keyword arguments when patching method. For Ruby 2.7+ we can use the `ruby2_keywords` method. Read more in https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/