### PR TITLE
Release v3.19.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v3.19.2
+
 ### Fixed
 
 Fix a bug when the given database configuration was already "exploded" with deprecated keys, e.g. `test_slave` or others ending with `_slave`.

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "3.19.1" do |s|
+Gem::Specification.new "active_record_shards", "3.19.2" do |s|
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"


### PR DESCRIPTION
Just one change, from #270:

> Fix a bug when the given database configuration was already "exploded" with deprecated keys, e.g. `test_slave` or others ending with `_slave`.