### PR TITLE
Memoize some methods that access the ActiveRecord configurations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ Naming/FileName:
     - 'lib/active_record_shards/connection_switcher-4-2.rb'
     - 'lib/active_record_shards/connection_switcher-5-0.rb'
     - 'lib/active_record_shards/connection_switcher-5-1.rb'
+    - 'lib/active_record_shards/connection_switcher-6-0.rb'
 
 Style/Alias:
   EnforcedStyle: prefer_alias_method

--- a/lib/active_record_shards/connection_switcher-6-0.rb
+++ b/lib/active_record_shards/connection_switcher-6-0.rb
@@ -1,0 +1,30 @@
+module ActiveRecordShards
+  module ConnectionSwitcher
+    def connection_specification_name
+      name = current_shard_selection.resolve_connection_name(sharded: is_sharded?, configurations: configurations)
+
+      @_ars_connection_specification_names ||= {}
+      unless @_ars_connection_specification_names.include?(name)
+        unless configurations[name] || name == "primary"
+          raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.to_h.keys.inspect})"
+        end
+
+        @_ars_connection_specification_names[name] = true
+      end
+
+      name
+    end
+
+    private
+
+    def ensure_shard_connection
+      # See if we've connected before. If not, call `#establish_connection`
+      # so that ActiveRecord can resolve connection_specification_name to an
+      # ARS connection.
+      spec_name = connection_specification_name
+
+      pool = connection_handler.retrieve_connection_pool(spec_name)
+      connection_handler.establish_connection(spec_name.to_sym) if pool.nil?
+    end
+  end
+end

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -221,8 +221,10 @@ when '4.2'
   require 'active_record_shards/connection_switcher-4-2'
 when '5.0'
   require 'active_record_shards/connection_switcher-5-0'
-when '5.1', '5.2', '6.0'
+when '5.1', '5.2'
   require 'active_record_shards/connection_switcher-5-1'
+when '6.0'
+  require 'active_record_shards/connection_switcher-6-0'
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"
 end

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -138,17 +138,26 @@ module ActiveRecordShards
     end
 
     def shard_names
-      unless config = configurations[shard_env]
-        raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.to_h.keys.inspect})"
-      end
-      unless config.fetch(SHARD_NAMES_CONFIG_KEY, []).all? { |shard_name| shard_name.is_a?(Integer) }
-        raise "All shard names must be integers: #{config[SHARD_NAMES_CONFIG_KEY].inspect}."
+      unless config_for_env.fetch(SHARD_NAMES_CONFIG_KEY, []).all? { |shard_name| shard_name.is_a?(Integer) }
+        raise "All shard names must be integers: #{config_for_env[SHARD_NAMES_CONFIG_KEY].inspect}."
       end
 
-      config[SHARD_NAMES_CONFIG_KEY] || []
+      config_for_env[SHARD_NAMES_CONFIG_KEY] || []
     end
 
     private
+
+    def config_for_env
+      @_ars_config_for_env ||= {}
+      @_ars_config_for_env[shard_env] ||= begin
+        unless config = configurations[shard_env]
+          raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.to_h.keys.inspect})"
+        end
+
+        config
+      end
+    end
+    alias_method :check_config_for_env, :config_for_env
 
     def switch_connection(options)
       if options.any?
@@ -157,9 +166,7 @@ module ActiveRecordShards
         end
 
         if options.key?(:shard)
-          unless configurations[shard_env]
-            raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.to_h.keys.inspect})"
-          end
+          check_config_for_env
 
           current_shard_selection.shard = options[:shard]
         end

--- a/test/check_performance.rb
+++ b/test/check_performance.rb
@@ -657,9 +657,9 @@ end
 
 # Results using Ruby 2.7.5
 #
-# 5.0.7.2 DB switching    191.200  (± 5.8%) i/s
-#   5.1.7 DB switching    187.008  (± 6.4%) i/s
-#   5.2.5 DB switching    190.104  (± 7.9%) i/s
-#   6.0.4 DB switching    151.729  (± 6.6%) i/s
+# 5.0.7.2 DB switching    207.457  (± 8.2%) i/s
+#   5.1.7 DB switching    211.790  (± 3.8%) i/s
+#   5.2.5 DB switching    213.797  (± 5.1%) i/s
+#   6.0.4 DB switching    216.607  (± 4.2%) i/s
 
 DbHelper.drop_databases


### PR DESCRIPTION
Rails 6 changed ActiveRecord configurations from a hash to a custom object. You can still access the configurations with Hash syntax but it gives deprecation warnings and is a lot slower.

This PR memoizes the configurations so we only have to do the slow access once. Needs to be changed to the new syntax (`configs_for`…) before that API is removed.

We updated the performance test with new results showing Rails 6.0 being significantly faster.