### PR TITLE
Drop Ruby 2.3 and 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - .git/**/*
     - gemfiles/vendor/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 # Configured cops
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+Removed support for Ruby 2.3 and 2.4.
+
 Removed support for Rails 4.2
 
 [Deprecation] Removes all deprecated methods containing `master`/`slave`. Use the updated `primary`/`replica` methods instead. The main public methods changed:

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new "active_record_shards", "3.19.1" do |s|
   s.description = "Easily run queries on shard and replica databases."
   s.license     = "MIT"
 
-  s.required_ruby_version = ">= 2.3"
+  s.required_ruby_version = ">= 2.5"
 
   s.add_runtime_dependency("activerecord", ">= 5.0", "< 6.1")
   s.add_runtime_dependency("activesupport", ">= 5.0", "< 6.1")

--- a/lib/active_record_shards/shard_support.rb
+++ b/lib/active_record_shards/shard_support.rb
@@ -23,12 +23,10 @@ module ActiveRecordShards
 
       exception = nil
       enum.each do
-        begin
-          record = @scope.find(*find_args)
-          return record if record
-        rescue ActiveRecord::RecordNotFound => e
-          exception = e
-        end
+        record = @scope.find(*find_args)
+        return record if record
+      rescue ActiveRecord::RecordNotFound => e
+        exception = e
       end
       raise exception
     end

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -78,14 +78,12 @@ namespace :db do
   namespace :test do
     desc 'Purges the test databases by dropping and creating'
     task purge: :load_config do |t|
-      begin
-        saved_env = Rails.env
-        Rails.env = 'test'
-        Rake.application.lookup('db:drop', t.scope).execute
-        Rake.application.lookup('db:create', t.scope).execute
-      ensure
-        Rails.env = saved_env
-      end
+      saved_env = Rails.env
+      Rails.env = 'test'
+      Rake.application.lookup('db:drop', t.scope).execute
+      Rake.application.lookup('db:create', t.scope).execute
+    ensure
+      Rails.env = saved_env
     end
   end
 end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -512,16 +512,14 @@ describe "connection switching" do
       describe "a inherited model without cached columns hash" do
         # before columns -> with_scope -> type-condition -> columns == loop
         it "not loop when on replica by default" do
-          begin
-            Person.on_replica_by_default = true
-            assert User.on_replica_by_default?
-            assert User.finder_needs_type_condition?
+          Person.on_replica_by_default = true
+          assert User.on_replica_by_default?
+          assert User.finder_needs_type_condition?
 
-            User.reset_column_information
-            User.columns_hash
-          ensure
-            Person.on_replica_by_default = false
-          end
+          User.reset_column_information
+          User.columns_hash
+        ensure
+          Person.on_replica_by_default = false
         end
       end
 

--- a/test/on_replica_by_default_test.rb
+++ b/test/on_replica_by_default_test.rb
@@ -331,13 +331,11 @@ describe ".on_replica_by_default" do
     end
 
     it "propagates the `on_replica_by_default` writer to inherited classes" do
-      begin
-        AccountInherited.on_replica_by_default = false
-        refute AccountInherited.on_replica_by_default?
-        refute Account.on_replica_by_default?
-      ensure
-        AccountInherited.on_replica_by_default = true
-      end
+      AccountInherited.on_replica_by_default = false
+      refute AccountInherited.on_replica_by_default?
+      refute Account.on_replica_by_default?
+    ensure
+      AccountInherited.on_replica_by_default = true
     end
   end
 end

--- a/test/tasks_test.rb
+++ b/test/tasks_test.rb
@@ -105,11 +105,9 @@ describe "Database rake tasks" do
     it "fails when migrations are pending" do
       ActiveRecord::Migrator.any_instance.stubs(:pending_migrations).returns([stub(version: 1, name: 'Fake')])
       out = capture_stderr do
-        begin
-          rake('db:abort_if_pending_migrations')
-        rescue SystemExit
-          ""
-        end
+        rake('db:abort_if_pending_migrations')
+      rescue SystemExit
+        ""
       end
       assert_match(/You have \d+ pending migrations:/, out)
     end


### PR DESCRIPTION
ruby-lang.org announced the end of support for Ruby 2.4 just about 2 years ago: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

