### PR TITLE
Remove instance method `#quote_value` patch

### DIFF
--- a/lib/active_record_shards/default_replica_patches.rb
+++ b/lib/active_record_shards/default_replica_patches.rb
@@ -44,11 +44,6 @@ module ActiveRecordShards
     end
 
     module InstanceMethods
-      # fix ActiveRecord to do the right thing, and use our aliased quote_value
-      def quote_value(*args, &block)
-        self.class.quote_value(*args, &block)
-      end
-
       def on_replica_unless_tx
         self.class.on_replica_unless_tx { yield }
       end


### PR DESCRIPTION
It looks like the instance method was removed in Rails 4.0.0 (which we no longer support): https://github.com/rails/rails/pull/7048