### PR TITLE
Add global setting to disable marking instances from replicas as read-only

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,12 @@ other methods changed:
 
 Also removes the class `ActiveRecordShards::Deprecation`.
 
+### Added
+
+Add a global setting to disable marking instances from replicas as read-only. To enable:
+
+`ActiveRecordShards.disable_replica_readonly_records = true`
+
 ## v3.19.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -148,11 +148,15 @@ ActiveRecord::Base.on_replica do
 end
 ```
 
-This will perform the query on the replica, and mark the returned instances as read only. There is also a shortcut for this:
+This will perform the query on the replica, and mark the returned instances as read-only. There is also a shortcut for this:
 
 ```ruby
 Account.on_replica.find_by_big_expensive_query
 ```
+
+If you do not want instances returned from replicas to be marked as read-only, this can be disabled globally:
+
+`ActiveRecordShards.disable_replica_readonly_records = true`
 
 ## Debugging
 

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -12,6 +12,10 @@ require 'active_record_shards/default_replica_patches'
 require 'active_record_shards/schema_dumper_extension'
 
 module ActiveRecordShards
+  class << self
+    attr_accessor :disable_replica_readonly_records
+  end
+
   def self.app_env
     env = Rails.env if defined?(Rails.env)
     env ||= RAILS_ENV if Object.const_defined?(:RAILS_ENV)

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -106,7 +106,7 @@ module ActiveRecordShards
 
       # we avoid_readonly_scope to prevent some stack overflow problems, like when
       # .columns calls .with_scope which calls .columns and onward, endlessly.
-      if self == ActiveRecord::Base || !switch_to_replica || construct_ro_scope == false
+      if self == ActiveRecord::Base || !switch_to_replica || construct_ro_scope == false || ActiveRecordShards.disable_replica_readonly_records == true
         yield
       else
         readonly.scoping(&block)

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -496,12 +496,40 @@ describe "connection switching" do
           assert_equal('replica_name', @model.name)
         end
 
-        it "be marked as read only" do
+        it "be marked as read-only" do
           assert(@model.readonly?)
         end
 
         it "be marked as comming from the replica" do
           assert(@model.from_replica?)
+        end
+
+        describe "when ActiveRecordShards.disable_replica_readonly_records is true" do
+          before do
+            @original_disable_replica_readonly_records = ActiveRecordShards.disable_replica_readonly_records
+            ActiveRecordShards.disable_replica_readonly_records = true
+
+            @model = Account.on_replica.find(1000)
+            assert(@model)
+            assert_equal('replica_name', @model.name)
+          end
+
+          it "read from replica on reload" do
+            @model.reload
+            assert_equal('replica_name', @model.name)
+          end
+
+          it "not be marked as read-only" do
+            refute(@model.readonly?)
+          end
+
+          it "be marked as comming from the replica" do
+            assert(@model.from_replica?)
+          end
+
+          after do
+            ActiveRecordShards.disable_replica_readonly_records = @original_disable_replica_readonly_records
+          end
         end
 
         after do
@@ -536,7 +564,7 @@ describe "connection switching" do
           assert(@model.readonly?)
         end
 
-        it "not be marked as read only" do
+        it "not be marked as read-only" do
           assert(!@model.readonly?)
         end
 


### PR DESCRIPTION
Add a global setting to disable marking instances from replicas as read-only. To enable:

```ActiveRecordShards.disable_replica_readonly_records = true```

This gives users the option to read from a replica and write to the leader. Users may accept the risk of replica delay, or implement appropriate mitigations, such as optimistic locking. (It should be noted that even reading from the primary does not protect against concurrent updates.)

This also avoids issues with test fixtures being marked as read-only, which conflicts with tests that expect to be able to modify fixtures. (An alternative solution to this issue could be to monkey-patch fixture generation to ensure test fixtures are not marked as read-only.)