### PR TITLE
Backport master branch features

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+Rename `ActiveRecordShards.rails_env` to `ActiveRecordShards.app_env`, and include `APP_ENV` and `ENV['APP_ENV']` in the list of places it looks for environment information.
+
 ## v3.19.3
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v3.20.0
+
 ### Changed
 
 Rename `ActiveRecordShards.rails_env` to `ActiveRecordShards.app_env`, and include `APP_ENV` and `ENV['APP_ENV']` in the list of places it looks for environment information.

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "3.19.3" do |s|
+Gem::Specification.new "active_record_shards", "3.20.0" do |s|
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -12,10 +12,12 @@ require 'active_record_shards/default_replica_patches'
 require 'active_record_shards/schema_dumper_extension'
 
 module ActiveRecordShards
-  def self.rails_env
+  def self.app_env
     env = Rails.env if defined?(Rails.env)
     env ||= RAILS_ENV if Object.const_defined?(:RAILS_ENV)
     env ||= ENV['RAILS_ENV']
+    env ||= APP_ENV if Object.const_defined?(:APP_ENV)
+    env ||= ENV['APP_ENV']
     env || 'development'
   end
 end

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -191,7 +191,7 @@ module ActiveRecordShards
     end
 
     def shard_env
-      ActiveRecordShards.rails_env
+      ActiveRecordShards.app_env
     end
 
     # Make these few schema related methods available before having switched to

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -26,11 +26,11 @@ module ActiveRecordShards
         the_shard = shard(klass)
 
         @shard_names ||= {}
-        @shard_names[ActiveRecordShards.rails_env] ||= {}
-        @shard_names[ActiveRecordShards.rails_env][the_shard] ||= {}
-        @shard_names[ActiveRecordShards.rails_env][the_shard][try_replica] ||= {}
-        @shard_names[ActiveRecordShards.rails_env][the_shard][try_replica][@on_replica] ||= begin
-          s = ActiveRecordShards.rails_env.dup
+        @shard_names[ActiveRecordShards.app_env] ||= {}
+        @shard_names[ActiveRecordShards.app_env][the_shard] ||= {}
+        @shard_names[ActiveRecordShards.app_env][the_shard][try_replica] ||= {}
+        @shard_names[ActiveRecordShards.app_env][the_shard][try_replica][@on_replica] ||= begin
+          s = ActiveRecordShards.app_env.dup
           s << "_shard_#{the_shard}" if the_shard
           s << "_replica"            if @on_replica && try_replica
           s
@@ -50,7 +50,7 @@ module ActiveRecordShards
       PRIMARY = "primary"
       def resolve_connection_name(sharded:, configurations:)
         resolved_shard = sharded ? shard : nil
-        env = ActiveRecordShards.rails_env
+        env = ActiveRecordShards.app_env
 
         @connection_names ||= {}
         @connection_names[env] ||= {}

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -10,7 +10,7 @@ namespace :db do
   desc 'Drops the database for the current RAILS_ENV including shards'
   task drop: :load_config do
     ActiveRecord::Base.configurations.to_h.each do |key, conf|
-      next if !key.start_with?(ActiveRecordShards.rails_env) || key.end_with?("_replica", "_slave")
+      next if !key.start_with?(ActiveRecordShards.app_env) || key.end_with?("_replica", "_slave")
 
       begin
         ActiveRecordShards::Tasks.root_connection(conf).drop_database(conf['database'])
@@ -31,7 +31,7 @@ namespace :db do
   desc "Create the database defined in config/database.yml for the current RAILS_ENV including shards"
   task create: :load_config do
     ActiveRecord::Base.configurations.to_h.each do |key, conf|
-      next if !key.start_with?(ActiveRecordShards.rails_env) || key.end_with?("_replica", "_slave")
+      next if !key.start_with?(ActiveRecordShards.app_env) || key.end_with?("_replica", "_slave")
 
       begin
         # MysqlAdapter takes charset instead of encoding in Rails 4.2 or greater
@@ -48,7 +48,7 @@ namespace :db do
         end
       end
     end
-    ActiveRecord::Base.establish_connection(ActiveRecordShards.rails_env.to_sym)
+    ActiveRecord::Base.establish_connection(ActiveRecordShards.app_env.to_sym)
   end
 
   desc "Raises an error if there are pending migrations"

--- a/test/active_record_shards_test.rb
+++ b/test/active_record_shards_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+describe 'ActiveRecordShards' do
+  describe '.app_env' do
+    before do
+      if defined?(Rails) || ENV['RAILS_ENV'] || defined?(APP_ENV) || ENV['APP_ENV']
+        raise "Tests in #{__FILE__} will overwrite environment constants, please update them to avoid conflicts"
+      end
+
+      Object.send(:remove_const, 'RAILS_ENV')
+    end
+
+    after { Object.const_set('RAILS_ENV', 'test') }
+
+    describe 'Rails.env' do
+      before do
+        class Rails
+          def self.env
+            'environment from Rails.env'
+          end
+        end
+      end
+
+      after { Object.send(:remove_const, 'Rails') }
+
+      it 'looks for Rails.env' do
+        assert_equal 'environment from Rails.env', ActiveRecordShards.app_env
+      end
+    end
+
+    describe 'RAILS_ENV' do
+      before { Object.const_set('RAILS_ENV', 'environment from RAILS_ENV') }
+      after { Object.send(:remove_const, 'RAILS_ENV') }
+
+      it 'looks for RAILS_ENV' do
+        assert_equal 'environment from RAILS_ENV', ActiveRecordShards.app_env
+      end
+    end
+
+    describe "ENV['RAILS_ENV']" do
+      before { ENV['RAILS_ENV'] = "environment from ENV['RAILS_ENV']" }
+      after { ENV.delete('RAILS_ENV') }
+
+      it 'looks for RAILS_ENV' do
+        assert_equal "environment from ENV['RAILS_ENV']", ActiveRecordShards.app_env
+      end
+    end
+
+    describe 'APP_ENV' do
+      before { Object.const_set('APP_ENV', 'environment from APP_ENV') }
+      after { Object.send(:remove_const, 'APP_ENV') }
+
+      it 'looks for APP_ENV' do
+        assert_equal 'environment from APP_ENV', ActiveRecordShards.app_env
+      end
+    end
+
+    describe "ENV['APP_ENV']" do
+      before { ENV['APP_ENV'] = "environment from ENV['APP_ENV']" }
+      after { ENV.delete('APP_ENV') }
+
+      it 'looks for APP_ENV' do
+        assert_equal "environment from ENV['APP_ENV']", ActiveRecordShards.app_env
+      end
+    end
+  end
+end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -340,7 +340,7 @@ describe "connection switching" do
   end
 
   describe "in an environment without replica" do
-    switch_rails_env('test3')
+    switch_app_env('test3')
     def spec_name
       ActiveRecord::Base.connection_pool.spec.name
     end
@@ -369,7 +369,7 @@ describe "connection switching" do
   end
 
   describe "in an unsharded environment" do
-    switch_rails_env('test2')
+    switch_app_env('test2')
 
     describe "shard switching" do
       it "just stay on the main db" do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -183,7 +183,7 @@ end
 Minitest::Spec.include(SpecHelpers)
 
 module RailsEnvSwitch
-  def switch_rails_env(env)
+  def switch_app_env(env)
     before do
       silence_warnings { Object.const_set("RAILS_ENV", env) }
       ActiveRecord::Base.establish_connection(::RAILS_ENV.to_sym)

--- a/test/migrator_test.rb
+++ b/test/migrator_test.rb
@@ -10,7 +10,7 @@ describe ActiveRecord::Migrator do
   describe "when DB is empty" do
     extend RailsEnvSwitch
 
-    switch_rails_env('test3')
+    switch_app_env('test3')
 
     it "makes meta tables" do
       ActiveRecord::Base.on_shard(nil) do


### PR DESCRIPTION
Backport of pull request #281 & bump version to v3.20.0.

ActiveRecordShards: rename rails_env to app_env, accept APP_ENV

The backport target (branch 3-x-stable) also supports Rails 4.2, so e.g. shard_selection.rb had to get a few more changes.