### PR TITLE
Bump version to v5.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v5.0.0
+
 ### Changed
 
 Rename `ActiveRecordShards.rails_env` to `ActiveRecordShards.app_env`, and include `APP_ENV` and `ENV['APP_ENV']` in the list of places it looks for environment information.

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "3.19.1" do |s|
+Gem::Specification.new "active_record_shards", "5.0.0" do |s|
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"


### PR DESCRIPTION
Yes, we didn't have any v4.0.0 release, but we did have a lot of v4.0.0-beta* releases a few years ago. And we don't want eventual users of one of those releases to think _this_ is the release they have been waiting for, finally out of beta.

No, this release is a breaking change both for users on 3.x.x and users on 4.0.0-beta*.