### PR TITLE
Add support for Rails 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - rails5.1
           - rails5.2
           - rails6.0
+          - rails6.1
         exclude:
           - ruby-version: "2.7"
             gemfile: rails5.1

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+Support for Rails 6.1 when `legacy_connection_handling` is set to `true`. This is required to [opt-out of the native Rails 6.1 sharding support](https://guides.rubyonrails.org/active_record_multiple_databases.html).
+
 ## v5.0.0
 
 ### Changed

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new "active_record_shards", "5.0.0" do |s|
 
   s.required_ruby_version = ">= 2.6"
 
-  s.add_runtime_dependency("activerecord", ">= 5.1", "< 6.1")
-  s.add_runtime_dependency("activesupport", ">= 5.1", "< 6.1")
+  s.add_runtime_dependency("activerecord", ">= 5.1", "< 7.0")
+  s.add_runtime_dependency("activesupport", ">= 5.1", "< 7.0")
 
   s.add_development_dependency("bump")
   s.add_development_dependency("minitest", ">= 5.10.0")

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,3 @@
+eval_gemfile 'common.rb'
+
+gem 'activerecord', '~> 6.1.0'

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -9,6 +9,7 @@ require 'active_record_shards/connection_switcher'
 require 'active_record_shards/association_collection_connection_selection'
 require 'active_record_shards/migration'
 require 'active_record_shards/default_replica_patches'
+require 'active_record_shards/default_shard'
 require 'active_record_shards/schema_dumper_extension'
 
 module ActiveRecordShards

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -61,7 +61,7 @@ when '5.2'
 
   # https://github.com/rails/rails/blob/v5.2.6/activerecord/lib/active_record/associations/preloader/association.rb#L96
   ActiveRecord::Associations::Preloader::Association.prepend(ActiveRecordShards::DefaultReplicaPatches::AssociationsPreloaderAssociationLoadRecordsPatch)
-when '6.0'
+when '6.0', '6.1'
   # https://github.com/rails/rails/blob/v6.0.4/activerecord/lib/active_record/type_caster/connection.rb#L28
   ActiveRecord::TypeCaster::Connection.prepend(ActiveRecordShards::DefaultReplicaPatches::TypeCasterConnectionConnectionPatch)
 

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -4,7 +4,11 @@ require 'active_record_shards/shard_support'
 
 module ActiveRecordShards
   module ConnectionSwitcher
-    SHARD_NAMES_CONFIG_KEY = 'shard_names'
+    if "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}" == '6.1'
+      SHARD_NAMES_CONFIG_KEY = :shard_names
+    else
+      SHARD_NAMES_CONFIG_KEY = 'shard_names'
+    end
 
     def self.extended(base)
       base.singleton_class.send(:alias_method, :load_schema_without_default_shard!, :load_schema!)

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -209,7 +209,7 @@ end
 case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
 when '5.1', '5.2'
   require 'active_record_shards/connection_switcher-5-1'
-when '6.0'
+when '6.0', '6.1'
   require 'active_record_shards/connection_switcher-6-0'
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -14,11 +14,6 @@ module ActiveRecordShards
       base.singleton_class.send(:alias_method, :table_exists?, :table_exists_with_default_shard?)
     end
 
-    def default_shard=(new_default_shard)
-      ActiveRecordShards::ShardSelection.default_shard = new_default_shard
-      switch_connection(shard: new_default_shard)
-    end
-
     def on_primary_db(&block)
       on_shard(nil, &block)
     end

--- a/lib/active_record_shards/default_shard.rb
+++ b/lib/active_record_shards/default_shard.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActiveRecordShards
+  module DefaultShard
+    def default_shard=(new_default_shard)
+      if ars_shard_type?(new_default_shard)
+        ActiveRecordShards::ShardSelection.ars_default_shard = new_default_shard
+        switch_connection(shard: new_default_shard)
+      else
+        super
+      end
+    end
+
+    private
+
+    def ars_shard_type?(shard)
+      return true if ActiveRecord.version < Gem::Version.new('6.1')
+      return true if shard.nil?
+      return true if shard == :_no_shard
+      return true if shard.is_a?(Integer)
+
+      false
+    end
+  end
+end
+
+ActiveRecord::Base.singleton_class.prepend(ActiveRecordShards::DefaultShard)

--- a/lib/active_record_shards/shard_selection.rb
+++ b/lib/active_record_shards/shard_selection.rb
@@ -3,7 +3,7 @@
 module ActiveRecordShards
   class ShardSelection
     NO_SHARD = :_no_shard
-    cattr_accessor :default_shard
+    cattr_accessor :ars_default_shard
 
     def initialize
       @on_replica = false
@@ -14,7 +14,7 @@ module ActiveRecordShards
       if @shard.nil? || @shard == NO_SHARD
         nil
       else
-        @shard || self.class.default_shard
+        @shard || self.class.ars_default_shard
       end
     end
 

--- a/lib/active_record_shards/tasks.rb
+++ b/lib/active_record_shards/tasks.rb
@@ -94,15 +94,22 @@ module ActiveRecordShards
       def root_connection(conf)
         conf = conf.merge('database' => nil)
         spec = spec_for(conf)
-
-        ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.config)
+        if "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}" == '6.1'
+          ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.db_config.configuration_hash)
+        else
+          ActiveRecord::Base.send("#{conf['adapter']}_connection", spec.config)
+        end
       end
 
       private
 
       def spec_for(conf)
-        resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations)
-        resolver.spec(conf)
+        if "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}" == '6.1'
+          ActiveRecord::Base.connection_handler.send(:resolve_pool_config, conf, ActiveRecord::Base)
+        else
+          resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations)
+          resolver.spec(conf)
+        end
       end
     end
   end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -342,7 +342,11 @@ describe "connection switching" do
   describe "in an environment without replica" do
     switch_app_env('test3')
     def spec_name
-      ActiveRecord::Base.connection_pool.spec.name
+      if "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}" == '6.1'
+        ActiveRecord::Base.connection_pool.db_config.name
+      else
+        ActiveRecord::Base.connection_pool.spec.name
+      end
     end
 
     describe "shard switching" do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -24,6 +24,8 @@ RAILS_ENV = "test"
 ActiveRecord::Base.logger = Logger.new(__dir__ + "/test.log")
 ActiveSupport.test_order = :sorted
 ActiveSupport::Deprecation.behavior = :raise
+ActiveSupport::Deprecation.behavior = :silence if "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}" == '6.1'
+ActiveRecord::Base.legacy_connection_handling = true if "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}" == '6.1'
 
 BaseMigration = ActiveRecord::Migration[4.2]
 


### PR DESCRIPTION
### Overview

Rails 6.1 added native support for horizontal sharding, making `active_record_shards` unnecessary. However, the implementation is quite different from the `active_record_shards` implementation and the upgrade path to Rails 6.1 is no simple task.

Thankfully, you can opt out of the new Rails 6.1 multiple database functionality by setting `ActiveRecord::Base.legacy_connection_handling` to `true`. This maintains almost the same database handling and allows apps to continuing using `active_record_shards` with Rails 6.1. This is the final version ARS will support, apps will **have** to remove ARS before upgrading to Rails 7. We may provide guidance on this before deprecating ARS.

### Default Shard Patch
One notable change: Rails 6.1 implements its own `default_shard` variable and `default_shard=` method. This broke `active_record_shards` which also implemented that variable and method.

To solve this the `default_shard` was renamed to `ars_default_shard` and `default_shard=` was moved into its own module and prepended onto `ActiveRecord::Base`. Because shards in Rails 6.1 are `symbols` but in ARS they are `integers`, `nil`, or `:_no_shard` we can conditionally set a variable depending on the type of shard we're passing:

```ruby
module ActiveRecordShards
  module DefaultShard
    def default_shard=(new_default_shard)
      if ars_shard_type?(new_default_shard)
        ActiveRecordShards::ShardSelection.ars_default_shard = new_default_shard
        switch_connection(shard: new_default_shard)
      else
        super
      end
    end

    private

    def ars_shard_type?(shard)
      return true if ActiveRecord.version < Gem::Version.new('6.1')
      return true if shard.nil?
      return true if shard == :_no_shard
      return true if shard.is_a?(Integer)
      return false
    end
  end
end

ActiveRecord::Base.singleton_class.prepend(ActiveRecordShards::DefaultShard)
```
