### PR TITLE
Silence ActiveSupport deprecation warnings

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,7 +23,7 @@ RAILS_ENV = "test"
 
 ActiveRecord::Base.logger = Logger.new(__dir__ + "/test.log")
 ActiveSupport.test_order = :sorted
-ActiveSupport::Deprecation.behavior = :raise
+ActiveSupport::Deprecation.behavior = :silence
 
 BaseMigration = ActiveRecord::Migration[4.2]
 


### PR DESCRIPTION
Rails 6.1 is the last Rails version active_record_shards will support and thus we can ignore the deprecation warnings that flood the test suite.