### PR TITLE
Add way to replace primary config with replica

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (from 3.17.0 onwards)
 
 ## [Unreleased]
+### Added
+
+`ActiveRecordShards.replace_with_replica_configuration` which takes 1 (or more) databases configuration keys and will overwrite those primary database configurations with their replica configurations. Useful for apps or environments that only need to read from specific databases.
 
 ## v5.1.0
 

--- a/lib/active_record_shards.rb
+++ b/lib/active_record_shards.rb
@@ -10,6 +10,7 @@ require 'active_record_shards/association_collection_connection_selection'
 require 'active_record_shards/migration'
 require 'active_record_shards/default_replica_patches'
 require 'active_record_shards/default_shard'
+require 'active_record_shards/primary_configs_to_replace'
 require 'active_record_shards/schema_dumper_extension'
 
 module ActiveRecordShards

--- a/lib/active_record_shards/configuration_parser.rb
+++ b/lib/active_record_shards/configuration_parser.rb
@@ -30,7 +30,7 @@ module ActiveRecordShards
         end
       end
 
-      conf
+      replace_primary_configs_with_replica_configs(conf)
     end
 
     def expand_child!(parent, child)
@@ -43,6 +43,26 @@ module ActiveRecordShards
 
     def configurations_with_shard_explosion=(conf)
       self.configurations_without_shard_explosion = explode(conf)
+    end
+
+    def replace_primary_configs_with_replica_configs(config)
+      ActiveRecordShards.configs_to_replace_with_replicas.each do |config_key|
+        replica_config = config["#{config_key}_replica"]
+        next unless replica_config.is_a?(Hash)
+
+        %w[adapter
+           database
+           host
+           password
+           port
+           username].each do |key|
+          if value = replica_config[key]
+            config[config_key][key] = value
+          end
+        end
+      end
+
+      config
     end
 
     def self.extended(base)

--- a/lib/active_record_shards/primary_configs_to_replace.rb
+++ b/lib/active_record_shards/primary_configs_to_replace.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveRecordShards
+  @@configs_to_replace_with_replicas = []
+
+  class << self
+    def configs_to_replace_with_replicas
+      @@configs_to_replace_with_replicas.uniq
+    end
+
+    def replace_with_replica_configuration(*config_keys)
+      config_keys.each do |key|
+        @@configs_to_replace_with_replicas << key.to_s
+      end
+    end
+  end
+end

--- a/test/active_record_shards/configuration_parser_test.rb
+++ b/test/active_record_shards/configuration_parser_test.rb
@@ -29,64 +29,135 @@ describe "ActiveRecordShards::ConfigurationParser.explode" do
     YAML
   end
 
-  before do
-    @exploded_conf = ActiveRecordShards::ConfigurationParser.explode(YAML.safe_load(yaml))
+  describe "without primary config replacement" do
+    before do
+      @exploded_conf = ActiveRecordShards::ConfigurationParser.explode(YAML.safe_load(yaml))
+    end
+
+    it "expands configuration for the main primary" do
+      config = @exploded_conf["test"]
+
+      shared_assertions(config)
+      assert_equal "main_host", config["host"]
+      assert_equal "ars_test", config["database"]
+    end
+
+    it "expands configuration for the main replica" do
+      config = @exploded_conf["test_replica"]
+
+      shared_assertions(config)
+      assert_equal "main_replica_host", config["host"]
+      assert_equal "ars_test", config["database"]
+    end
+
+    it "expands configuration for shard 500's primary" do
+      config = @exploded_conf["test_shard_500"]
+
+      shared_assertions(config)
+      assert_equal "shard_500_host", config["host"]
+      assert_equal "ars_test_shard_500", config["database"]
+    end
+
+    it "expands configuration for shard 500's replica" do
+      config = @exploded_conf["test_shard_500_replica"]
+
+      shared_assertions(config)
+      assert_equal "shard_500_replica_host", config["host"]
+      assert_equal "ars_test_shard_500", config["database"]
+    end
+
+    it "expands configuration for shard 501's primary" do
+      config = @exploded_conf["test_shard_501"]
+
+      shared_assertions(config)
+      assert_equal "shard_501_host", config["host"]
+      assert_equal "ars_test_shard_501", config["database"]
+    end
+
+    it "expands configuration for shard 501's replica" do
+      config = @exploded_conf["test_shard_501_replica"]
+
+      shared_assertions(config)
+      assert_equal "shard_501_host", config["host"]
+      assert_equal "ars_test_shard_501_replica", config["database"]
+    end
+
+    def shared_assertions(config)
+      assert_equal "mysql", config["adapter"]
+      assert_equal "utf8", config["encoding"]
+      assert_equal 123, config["port"]
+      assert_equal "root", config["username"]
+      assert_nil config["password"]
+      assert_equal [500, 501], config["shard_names"]
+    end
   end
 
-  it "expands configuration for the main primary" do
-    config = @exploded_conf["test"]
+  describe "with primary config replacement" do
+    before do
+      @yaml_with_full_replica_config =
+        <<~YAML
+          test:
+            adapter: mysql
+            encoding: utf8
+            database: ars_test
+            port: 123
+            username: root
+            password:
+            host: main_host
+            replica:
+              adapter: mysql2
+              database: replica_database
+              host: main_replica_host
+              password: replica_password
+              port: 12345
+              username: replica_username
+            shards:
+              500:
+                database: ars_test_shard_500
+                host: shard_500_host
+                replica:
+                  adapter: mysql2
+                  database: shard_500_replica_database
+                  host: shard_500_replica_host
+                  password: shard_500_replica_password
+                  port: 12345
+                  username: shard_500_replica_username
+        YAML
+    end
 
-    shared_assertions(config)
-    assert_equal "main_host", config["host"]
-    assert_equal "ars_test", config["database"]
-  end
+    it "changes one configuration with its replica configuration" do
+      ActiveRecordShards.replace_with_replica_configuration "test"
+      exploded_conf = ActiveRecordShards::ConfigurationParser.explode(YAML.safe_load(@yaml_with_full_replica_config))
 
-  it "expands configuration for the main replica" do
-    config = @exploded_conf["test_replica"]
+      assert_equal exploded_conf["test"]["adapter"], "mysql2"
+      assert_equal exploded_conf["test"]["database"], "replica_database"
+      assert_equal exploded_conf["test"]["host"], "main_replica_host"
+      assert_equal exploded_conf["test"]["password"], "replica_password"
+      assert_equal exploded_conf["test"]["port"], 12345
+      assert_equal exploded_conf["test"]["username"], "replica_username"
+    end
 
-    shared_assertions(config)
-    assert_equal "main_replica_host", config["host"]
-    assert_equal "ars_test", config["database"]
-  end
+    it "changes multiple configurations with their replica configuration" do
+      ActiveRecordShards.replace_with_replica_configuration "test", "test_shard_500"
+      exploded_conf = ActiveRecordShards::ConfigurationParser.explode(YAML.safe_load(@yaml_with_full_replica_config))
 
-  it "expands configuration for shard 500's primary" do
-    config = @exploded_conf["test_shard_500"]
+      assert_equal exploded_conf["test"]["adapter"], "mysql2"
+      assert_equal exploded_conf["test"]["database"], "replica_database"
+      assert_equal exploded_conf["test"]["host"], "main_replica_host"
+      assert_equal exploded_conf["test"]["password"], "replica_password"
+      assert_equal exploded_conf["test"]["port"], 12345
+      assert_equal exploded_conf["test"]["username"], "replica_username"
 
-    shared_assertions(config)
-    assert_equal "shard_500_host", config["host"]
-    assert_equal "ars_test_shard_500", config["database"]
-  end
+      assert_equal exploded_conf["test_shard_500"]["adapter"], "mysql2"
+      assert_equal exploded_conf["test_shard_500"]["database"], "shard_500_replica_database"
+      assert_equal exploded_conf["test_shard_500"]["host"], "shard_500_replica_host"
+      assert_equal exploded_conf["test_shard_500"]["password"], "shard_500_replica_password"
+      assert_equal exploded_conf["test_shard_500"]["port"], 12345
+      assert_equal exploded_conf["test_shard_500"]["username"], "shard_500_replica_username"
+    end
 
-  it "expands configuration for shard 500's replica" do
-    config = @exploded_conf["test_shard_500_replica"]
-
-    shared_assertions(config)
-    assert_equal "shard_500_replica_host", config["host"]
-    assert_equal "ars_test_shard_500", config["database"]
-  end
-
-  it "expands configuration for shard 501's primary" do
-    config = @exploded_conf["test_shard_501"]
-
-    shared_assertions(config)
-    assert_equal "shard_501_host", config["host"]
-    assert_equal "ars_test_shard_501", config["database"]
-  end
-
-  it "expands configuration for shard 501's replica" do
-    config = @exploded_conf["test_shard_501_replica"]
-
-    shared_assertions(config)
-    assert_equal "shard_501_host", config["host"]
-    assert_equal "ars_test_shard_501_replica", config["database"]
-  end
-
-  def shared_assertions(config)
-    assert_equal "mysql", config["adapter"]
-    assert_equal "utf8", config["encoding"]
-    assert_equal 123, config["port"]
-    assert_equal "root", config["username"]
-    assert_nil config["password"]
-    assert_equal [500, 501], config["shard_names"]
+    after do
+      ActiveRecordShards.class_variable_set(:@@configs_to_replace_with_replicas, [])
+    end
   end
 end


### PR DESCRIPTION
This introduces a new `ActiveRecordShards` class method `replace_with_replica_configuration`.

You can pass it 1 (or more) database configuration key names and `ActiveRecordShards` will then replace the associated database configuration with its replica configuration, ensuring the primary cannot be connected to.

Example usage with `production` and `shard_1` primary databases:

```ruby
# config/application.rb (or somewhere else that is called before the app is initialized)

ActiveRecordShards.replace_with_replica_configuration "primary", "shard_1"
```