### PR TITLE
Fix Rails 6.1 deprecation warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ Naming/FileName:
   Exclude:
     - 'lib/active_record_shards/connection_switcher-5-1.rb'
     - 'lib/active_record_shards/connection_switcher-6-0.rb'
+    - 'lib/active_record_shards/connection_switcher-6-1.rb'
 
 Style/Alias:
   EnforcedStyle: prefer_alias_method

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+Rails 6.1 deprecation warnings.
+
 ## v5.1.0
 
 ### Added

--- a/lib/active_record_shards/connection_switcher-6-1.rb
+++ b/lib/active_record_shards/connection_switcher-6-1.rb
@@ -1,0 +1,31 @@
+module ActiveRecordShards
+  module ConnectionSwitcher
+    def connection_specification_name
+      name = current_shard_selection.resolve_connection_name(sharded: is_sharded?, configurations: configurations)
+
+      @_ars_connection_specification_names ||= {}
+      unless @_ars_connection_specification_names.include?(name)
+        unless configurations.configs_for(env_name: name, include_replicas: true).any? || name == "ActiveRecord::Base"
+          raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.configurations.map(&:env_name).inspect})"
+        end
+
+        @_ars_connection_specification_names[name] = true
+      end
+
+      name
+    end
+
+    private
+
+    def ensure_shard_connection
+      # See if we've connected before. If not, call `#establish_connection`
+      # so that ActiveRecord can resolve connection_specification_name to an
+      # ARS connection.
+      spec_name = connection_specification_name
+
+      pool = connection_handler.retrieve_connection_pool(spec_name)
+
+      connection_handler.establish_connection(spec_name.to_sym) if pool.nil?
+    end
+  end
+end

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -144,7 +144,13 @@ module ActiveRecordShards
     def config_for_env
       @_ars_config_for_env ||= {}
       @_ars_config_for_env[shard_env] ||= begin
-        unless config = configurations[shard_env]
+        case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+        when '6.1'
+          config = configurations.configs_for(env_name: shard_env, include_replicas: true).first.configuration_hash
+        else
+          config = configurations[shard_env]
+        end
+        unless config
           raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.to_h.keys.inspect})"
         end
 
@@ -208,8 +214,10 @@ end
 case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
 when '5.1', '5.2'
   require 'active_record_shards/connection_switcher-5-1'
-when '6.0', '6.1'
+when '6.0'
   require 'active_record_shards/connection_switcher-6-0'
+when '6.1'
+  require 'active_record_shards/connection_switcher-6-1'
 else
   raise "ActiveRecordShards is not compatible with #{ActiveRecord::VERSION::STRING}"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -24,7 +24,6 @@ RAILS_ENV = "test"
 ActiveRecord::Base.logger = Logger.new(__dir__ + "/test.log")
 ActiveSupport.test_order = :sorted
 ActiveSupport::Deprecation.behavior = :raise
-ActiveSupport::Deprecation.behavior = :silence if "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}" == '6.1'
 ActiveRecord::Base.legacy_connection_handling = true if "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}" == '6.1'
 
 BaseMigration = ActiveRecord::Migration[4.2]


### PR DESCRIPTION
This adds a new `connection_switch-6-1.rb` file. You can see what needed to be changed from `6.0` with:

```diff
diff lib/active_record_shards/connection_switcher-6-0.rb lib/active_record_shards/connection_switcher-6-1.rb

- unless configurations[name] || name == "primary"
-   raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.to_h.keys.inspect})"
+ unless configurations.configs_for(env_name: name, include_replicas: true).any? || name == "ActiveRecord::Base"
+   raise ActiveRecord::AdapterNotSpecified, "No database defined by #{name} in your database config. (configurations: #{configurations.configurations.map(&:env_name).inspect})"
```