### PR TITLE
Remove Mocha gem

### DIFF
--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new "active_record_shards", "5.3.0" do |s|
   s.add_development_dependency("bump")
   s.add_development_dependency("minitest", ">= 5.10.0")
   s.add_development_dependency("minitest-rg")
-  s.add_development_dependency("mocha", ">= 1.4.0")
   s.add_development_dependency("mysql2")
   s.add_development_dependency("rake", '~> 12.0')
   s.add_development_dependency("rubocop", "~> 0.77.0")

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,7 +9,6 @@ require 'minitest/autorun'
 require 'minitest/rg'
 require 'rake'
 
-require 'mocha/minitest'
 Bundler.require
 
 $LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))


### PR DESCRIPTION
Mocha is a large gem, and it includes e.g. `any_instance` which seems like an anti-pattern. At least I think that when `any_instance` is in use, I don’t _really_ know what is going on during the test. If you can define and return (and stub on) _one_ instance, things are much easier to follow.

I was about to add the "minitest-mock_expectations" gem to replace Mocha’s `#expects` method when I realised that in those cases we actually only need the stub - no mocking is necessary. And Minitest’s built-in stubbing works just fine.