### PR TITLE
Raise when legacy_connection_handling is false

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v5.3.1
+
+### Added
+Raises a new `LegacyConnectionHandlingError` exception when using ActiveRecord >= 6.1 and `legacy_connection_handling` is set to `false`.
+
 ## v5.3.0
 
 ### Fixed

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "5.3.0" do |s|
+Gem::Specification.new "active_record_shards", "5.3.1" do |s|
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"


### PR DESCRIPTION
ActiveRecordShards does **not work** when `legacy_connection_handling` is `false`. While that's stated in the readme,  for extra security let's raise an exception if it's been set incorrectly.