### PR TITLE
Check if shard names are integers when caching the configurations

### DIFF
--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -142,10 +142,6 @@ module ActiveRecordShards
     end
 
     def shard_names
-      unless config_for_env.fetch(SHARD_NAMES_CONFIG_KEY, []).all? { |shard_name| shard_name.is_a?(Integer) }
-        raise "All shard names must be integers: #{config_for_env[SHARD_NAMES_CONFIG_KEY].inspect}."
-      end
-
       config_for_env[SHARD_NAMES_CONFIG_KEY] || []
     end
 
@@ -166,10 +162,18 @@ module ActiveRecordShards
           raise "Did not find #{shard_env} in configurations, did you forget to add it to your database config? (configurations: #{configurations.to_h.keys.inspect})"
         end
 
+        ensure_all_shard_names_are_integers(config)
+
         config
       end
     end
     alias_method :check_config_for_env, :config_for_env
+
+    def ensure_all_shard_names_are_integers(config)
+      unless config.fetch(SHARD_NAMES_CONFIG_KEY, []).all? { |shard_name| shard_name.is_a?(Integer) }
+        raise "All shard names must be integers: #{config.inspect}."
+      end
+    end
 
     def switch_connection(options)
       ensure_legacy_connection_handling if ActiveRecord.version >= Gem::Version.new('6.1')


### PR DESCRIPTION
An alternative, or an addition to, #311

We only need to verify that all of the shard names are integers _once_, otherwise we will perform an expensive integer check on every shard name, every time we call `shard_names`.