### PR TITLE
Allow devs to use Rails 5.1 with mysql2 v0.5.x

### DIFF
--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,4 +1,3 @@
 eval_gemfile 'common.rb'
 
-gem 'activerecord', '~> 5.1.3'
-gem 'mysql2', '>= 0.3.18', '< 0.5'
+gem 'activerecord', '~> 5.1.6'


### PR DESCRIPTION
ActiveRecord v5.1.6 allows using mysql2 0.5.x.