### PR TITLE
CI: Simplify test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,29 +23,19 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"
         gemfile:
-          - rails5.1
-          - rails5.2
-          - rails6.0
           - rails6.1
           - rails7.0
-        exclude:
-          - {ruby-version: "2.6", gemfile: rails7.0}
-          - {ruby-version: "2.7", gemfile: rails5.1}
-          - {ruby-version: "2.7", gemfile: rails5.2}
-          - {ruby-version: "3.0", gemfile: rails5.1}
-          - {ruby-version: "3.0", gemfile: rails5.2}
-          - {ruby-version: "3.1", gemfile: rails5.1}
-          - {ruby-version: "3.1", gemfile: rails5.2}
-          - {ruby-version: "3.1", gemfile: rails6.0}
-          - {ruby-version: "3.2", gemfile: rails5.1}
-          - {ruby-version: "3.2", gemfile: rails5.2}
-          - {ruby-version: "3.2", gemfile: rails6.0}
+        include:
+          - {ruby-version: "2.6", gemfile: rails5.1}
+          - {ruby-version: "2.6", gemfile: rails5.2}
+          - {ruby-version: "2.6", gemfile: rails6.0}
+          - {ruby-version: "2.6", gemfile: rails6.1}
+          - {ruby-version: "2.7", gemfile: rails6.0}
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
@@ -75,7 +65,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - name: Set up Ruby
         uses: zendesk/setup-ruby@v1
         with:


### PR DESCRIPTION
Since Rails 5.1, 5.2, 6.0 are only tested with Ruby 2.6 and 2.7, we can remove a lot of "excludes" by adding a few "includes" to the test matrix.