### PR TITLE
Maintain shard_selection with Thread local vars

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+* Stays on the correct database, even when using a new Fiber. Some Ruby methods, such as `to_enum` create a new Fiber for the block. `to_enum` is used by ActiveRecord when finding things in batches. This should resolve issues where ARS would connect to the unsharded database, even inside an `on_shard` block. The downside is we are now violating fiber concurrency and thus this breaks multi-fiber webservers.
 
-Fixes an issue where ARS switches to the replica database in the middle of a transaction when it is supposed to remain on the Primary.
+*Fixes an issue where ARS switches to the replica database in the middle of a transaction when it is supposed to remain on the Primary.
 
 ## v5.3.3
 

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -134,7 +134,8 @@ module ActiveRecordShards
     end
 
     def current_shard_selection
-      Thread.current[:shard_selection] ||= ShardSelection.new
+      cs = Thread.current.thread_variable_get(:shard_selection) || ShardSelection.new
+      Thread.current.thread_variable_set(:shard_selection, cs)
     end
 
     def current_shard_id

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -5,6 +5,7 @@ require 'active_record_shards/shard_support'
 module ActiveRecordShards
   module ConnectionSwitcher
     class LegacyConnectionHandlingError < StandardError; end
+    class IsolationLevelError < StandardError; end
 
     case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
     when '6.1', '7.0'
@@ -178,6 +179,7 @@ module ActiveRecordShards
 
     def switch_connection(options)
       ensure_legacy_connection_handling if ActiveRecord.version >= Gem::Version.new('6.1')
+      ensure_thread_isolation_level if ActiveRecord.version >= Gem::Version.new('7.0')
 
       if options.any?
         if options.key?(:replica)
@@ -197,6 +199,12 @@ module ActiveRecordShards
     def ensure_legacy_connection_handling
       unless legacy_connection_handling_owner.legacy_connection_handling
         raise LegacyConnectionHandlingError, "ActiveRecordShards is _only_ compatible with ActiveRecord `legacy_connection_handling` set to `true`."
+      end
+    end
+
+    def ensure_thread_isolation_level
+      unless ActiveSupport::IsolatedExecutionState.isolation_level == :thread
+        raise IsolationLevelError, "ActiveRecordShards is _only_ compatible when ActiveSupport::IsolatedExecutionState's isolation_level is set to :thread"
       end
     end
 


### PR DESCRIPTION
To keep track of the existing shard we are currently calling:

```ruby
Thread.current[:shard_selection] = "foo"
```

This sets a *fiber-local* variable which is only accessible in the context of the current Fiber.

Example from the Ruby docs:

```ruby
Thread.new {
  Thread.current[:foo] = "bar"
  Fiber.new {
    p Thread.current[:foo] # => nil
  }.resume
}.join
```

Normally, this would be fine _except_ there are some Ruby methods, that ActiveRecord utilizes, that actually _change_ the Fiber underneath us. Let's take the ActiveRecord method `find_in_batches` as an example which calls `Object#to_enum`:

```ruby
# lib/active_record/relation/batches.rb:129 ActiveRecord::Batches#find_in_batches:

    126: def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil)
    127:   relation = self
    128:   unless block_given?
 => 129:     return to_enum(:find_in_batches, start: start, finish: finish, batch_size: batch_size, error_on_ignore: error_on_ignore) do
    130:       total = apply_limits(relation, start, finish).size
    131:       (total - 1).div(batch_size) + 1
    132:     end
    133:   end
    134:
    135:   in_batches(of: batch_size, start: start, finish: finish, load: true, error_on_ignore: error_on_ignore) do |batch|
    136:     yield batch.to_a
    137:   end
    138: end

Fiber.current.object_id => 2800 # note the Fiber id

Thread.current[:shard_selection] => #<ActiveRecordShards::ShardSelection:0x000000010a4f5870

Thread.current[:shard_selection].shard => 0

step

# lib/active_record/relation/batches.rb:127 ActiveRecord::Batches#find_in_batches:

    126: def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil)
 => 127:   relation = self
    128:   unless block_given?
    129:     return to_enum(:find_in_batches, start: start, finish: finish, batch_size: batch_size, error_on_ignore: error_on_ignore) do
    130:       total = apply_limits(relation, start, finish).size
    131:       (total - 1).div(batch_size) + 1
    132:     end
    133:   end
    134:
    135:   in_batches(of: batch_size, start: start, finish: finish, load: true, error_on_ignore: error_on_ignore) do |batch|
    136:     yield batch.to_a
    137:   end
    138: end

Fiber.current.object_id => 2820 # brand new fiber

Thread.current[:shard_selection] => nil # we've lost the Shard Selection
```

`to_enum`, defined in Ruby C code, creates a new fiber and executes the block in that context.

The fix is to use `Thread.current.thread_variable_set` instead of `Thread.current[]`. `current_variable_set` sets a _thread_ local variable and new fibers keep access to that context:

From the Ruby Docs:

```ruby
Thread.new{
  Thread.current.thread_variable_set(:foo, 1)
  p Thread.current.thread_variable_get(:foo) # => 1
  Fiber.new{
    Thread.current.thread_variable_set(:foo, 2)
    p Thread.current.thread_variable_get(:foo) # => 2
  }.resume
  p Thread.current.thread_variable_get(:foo)   # => 2
}.join
```

Because this violates fiber concurrency on Rails 7 (which is a configurable option) we now raise an error if `ActiveSupport::IsolatedExecutionState.isolation_level` is not set to `:thread` (which is the default).