### PR TITLE
Failing test for changed #save behaviour in Rails 6.1

### DIFF
--- a/test/on_replica_by_default_test.rb
+++ b/test/on_replica_by_default_test.rb
@@ -338,4 +338,16 @@ describe ".on_replica_by_default" do
       AccountInherited.on_replica_by_default = true
     end
   end
+
+  describe 'inside an #after_save hook' do
+    it 'performs reads on the primary' do
+      model = Account.on_primary.find(1000)
+      model.name = 'bartfoo'
+      model.singleton_class.after_save do
+        @fetched_person = Person.find(10)
+      end
+      model.save!
+      assert_equal "Primary person", model.instance_variable_get(:@fetched_person).name
+    end
+  end
 end


### PR DESCRIPTION
This test fails on Rails 6.1 but passes on 6.0. I suspect this commit in Rails is what broke it: https://github.com/rails/rails/commit/77f7b2df3aa3b7eb318cc830f239fd5ec2a7f28f

that makes save no longer call ActiveRecord::Base.transaction, but instead makes it call #transaction directly on the connection. That means that [this patch](https://github.com/zendesk/active_record_shards/blob/21beeeedf73849a8a3a9a0924dff1051601a0c49/lib/active_record_shards/default_replica_patches.rb#L86) in active_record_shards doesn’t see that it’s in a transaction now, so `Thread.current[:_active_record_shards_in_tx]` is nil and so reads get issued against the replica still.