### PR TITLE
Refactor on_replica_unless_tx

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+Fixes an issue where ARS switches to the replica database in the middle of a transaction when it is supposed to remain on the Primary.
+
 ## v5.3.3
 
 ### Added

--- a/lib/active_record_shards/default_replica_patches.rb
+++ b/lib/active_record_shards/default_replica_patches.rb
@@ -29,21 +29,6 @@ module ActiveRecordShards
       RUBY
     end
 
-    def transaction_with_replica_off(*args, &block)
-      if on_replica_by_default?
-        begin
-          old_val = Thread.current[:_active_record_shards_in_tx]
-          Thread.current[:_active_record_shards_in_tx] = true
-          transaction_without_replica_off(*args, &block)
-        ensure
-          Thread.current[:_active_record_shards_in_tx] = old_val
-        end
-      else
-        transaction_without_replica_off(*args, &block)
-      end
-    end
-    ruby2_keywords(:transaction_with_replica_off) if respond_to?(:ruby2_keywords, true)
-
     module InstanceMethods
       def on_replica_unless_tx
         self.class.on_replica_unless_tx { yield }
@@ -80,17 +65,11 @@ module ActiveRecordShards
 
       base.class_eval do
         include InstanceMethods
-
-        class << self
-          alias_method :transaction_without_replica_off, :transaction
-          alias_method :transaction, :transaction_with_replica_off
-        end
       end
     end
 
     def on_replica_unless_tx(&block)
       return yield if Thread.current[:_active_record_shards_in_migration]
-      return yield if Thread.current[:_active_record_shards_in_tx]
       return yield if _in_transaction?
 
       if on_replica_by_default?
@@ -127,7 +106,6 @@ module ActiveRecordShards
     module Rails52RelationPatches
       def connection
         return super if Thread.current[:_active_record_shards_in_migration]
-        return super if Thread.current[:_active_record_shards_in_tx]
         return super if _in_transaction?
 
         if @klass.on_replica_by_default?
@@ -220,7 +198,6 @@ module ActiveRecordShards
     module TypeCasterConnectionConnectionPatch
       def connection
         return super if Thread.current[:_active_record_shards_in_migration]
-        return super if Thread.current[:_active_record_shards_in_tx]
         return super if ActiveRecord::Base._in_transaction?
 
         if @klass.on_replica_by_default?

--- a/test/on_replica_by_default_test.rb
+++ b/test/on_replica_by_default_test.rb
@@ -338,4 +338,16 @@ describe ".on_replica_by_default" do
       AccountInherited.on_replica_by_default = true
     end
   end
+
+  describe 'inside an #after_save hook' do
+    it 'performs reads on the primary' do
+      model = Account.on_primary.find(1000)
+      model.name = 'bartfoo'
+      model.singleton_class.after_save do
+        @fetched_person = Person.find(10)
+      end
+      model.save!
+      assert_equal "Primary person", model.instance_variable_get(:@fetched_person).name
+    end
+  end
 end


### PR DESCRIPTION
Currently, ARS aliases `.transaction` on `ActiveRecord::Base` to set a fiber-local variable.

However, Rails will now call `#transaction` on the [connection _itself_](https://github.com/rails/rails/commit/77f7b2df3aa3b7eb318cc830f239fd5ec2a7f28f) and thus ARS was unaware that it was in the middle of a transaction.

This PR removes the patch and instead uses Rails internals to check if we're in a transaction or not. If we are, we don't switch to the replica.

Performance comparison:

`main` branch:
```
$ bundle exec ruby -v test/check_performance.rb

ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]
Warming up --------------------------------------
7.0.3.1 DB switching    46.000  i/100ms
Calculating -------------------------------------
7.0.3.1 DB switching    466.341  (± 6.2%) i/s -      2.346k in   5.050940s
```

This branch:
```
$ bundle exec ruby -v test/check_performance.rb

ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]
Warming up --------------------------------------
7.0.3.1 DB switching    49.000  i/100ms
Calculating -------------------------------------
7.0.3.1 DB switching    459.929  (± 7.2%) i/s -      2.303k in   5.033812s
```
