### PR TITLE
Release v5.4.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v5.4.0
+
+### Changed
+* Now raises an error in Rails 7.0 when attempting to use ARS when `ActiveSupport::IsolatedExecutionState.isolation_level` is not set to `:thread`
+
 ### Fixed
 * Stays on the correct database, even when using a new Fiber. Some Ruby methods, such as `to_enum` create a new Fiber for the block. `to_enum` is used by ActiveRecord when finding things in batches. This should resolve issues where ARS would connect to the unsharded database, even inside an `on_shard` block. The downside is we are now violating fiber concurrency and thus this breaks multi-fiber webservers.
 
-*Fixes an issue where ARS switches to the replica database in the middle of a transaction when it is supposed to remain on the Primary.
+* Fixes an issue where ARS switches to the replica database in the middle of a transaction when it is supposed to remain on the Primary.
 
 ## v5.3.3
 

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "5.3.3" do |s|
+Gem::Specification.new "active_record_shards", "5.4.0" do |s|
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"


### PR DESCRIPTION
Changed
- Now raises an error in Rails 7.0 when attempting to use ARS when `ActiveSupport::IsolatedExecutionState.isolation_level` is not set to `:thread`

Fixed
- Stays on the correct database, even when using a new Fiber. Some Ruby methods, such as `to_enum` create a new Fiber for the block. `to_enum` is used by ActiveRecord when finding things in batches. This should resolve issues where ARS would connect to the unsharded database, even inside an `on_shard` block. The downside is we are now violating fiber concurrency and thus this breaks multi-fiber webservers.

- Fixes an issue where ARS switches to the replica database in the middle of a transaction when it is supposed to remain on the Primary.