### PR TITLE
Use Thread.attr_accessor to set thread-local vars, release v5.4.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v5.4.1
+
+### Fixed
+* Changes all fiber-local variables to thread-local variables. Fixes any lingering issues where a fiber change could cause the state to be lost.
+
 ## v5.4.0
 
 ### Changed

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "5.4.0" do |s|
+Gem::Specification.new "active_record_shards", "5.4.1" do |s|
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"

--- a/lib/active_record_shards/default_replica_patches.rb
+++ b/lib/active_record_shards/default_replica_patches.rb
@@ -69,7 +69,7 @@ module ActiveRecordShards
     end
 
     def on_replica_unless_tx(&block)
-      return yield if Thread.current[:_active_record_shards_in_migration]
+      return yield if Thread.current._active_record_shards_in_migration
       return yield if _in_transaction?
 
       if on_replica_by_default?
@@ -84,7 +84,7 @@ module ActiveRecordShards
     end
 
     def force_on_replica(&block)
-      return yield if Thread.current[:_active_record_shards_in_migration]
+      return yield if Thread.current._active_record_shards_in_migration
 
       on_cx_switch_block(:replica, construct_ro_scope: false, force: true, &block)
     end
@@ -105,7 +105,7 @@ module ActiveRecordShards
 
     module Rails52RelationPatches
       def connection
-        return super if Thread.current[:_active_record_shards_in_migration]
+        return super if Thread.current._active_record_shards_in_migration
         return super if _in_transaction?
 
         if @klass.on_replica_by_default?
@@ -197,7 +197,7 @@ module ActiveRecordShards
 
     module TypeCasterConnectionConnectionPatch
       def connection
-        return super if Thread.current[:_active_record_shards_in_migration]
+        return super if Thread.current._active_record_shards_in_migration
         return super if ActiveRecord::Base._in_transaction?
 
         if @klass.on_replica_by_default?
@@ -210,11 +210,11 @@ module ActiveRecordShards
 
     module SchemaDefinePatch
       def define(info, &block)
-        old_val = Thread.current[:_active_record_shards_in_migration]
-        Thread.current[:_active_record_shards_in_migration] = true
+        old_val = Thread.current._active_record_shards_in_migration
+        Thread.current._active_record_shards_in_migration = true
         super
       ensure
-        Thread.current[:_active_record_shards_in_migration] = old_val
+        Thread.current._active_record_shards_in_migration = old_val
       end
     end
   end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -454,7 +454,7 @@ describe "connection switching" do
         else
           @saved_config = ActiveRecord::Base.configurations.delete('test_replica')
         end
-        Thread.current.thread_variable_set(:shard_selection, nil) # drop caches
+        Thread.current._active_record_shards_shard_selection = nil # drop caches
         clear_connection_pool
         ActiveRecord::Base.establish_connection(:test)
       end
@@ -465,7 +465,7 @@ describe "connection switching" do
         else
           ActiveRecord::Base.configurations['test_replica'] = @saved_config
         end
-        Thread.current.thread_variable_set(:shard_selection, nil) # drop caches
+        Thread.current._active_record_shards_shard_selection = nil # drop caches
       end
 
       it "default to the primary database" do


### PR DESCRIPTION
This is a follow-up to #319

We can simplify things by creating `attr_accessor`s for the thread-local variables that ARS uses.

This cleans up the last few variables that were fiber-local and _not_ thread-local (we need them to be thread-local)

Verification that `attr_accessor` sets thread-locals:

```ruby
Thread.attr_accessor :foo => [:foo, :foo=]
Thread.current.foo = "bar"
Thread.current.foo => "bar"
Fiber.new { puts Thread.current.foo }.resume => bar
```

This also releases `v5.4.1`