### PR TITLE
Ensure default shard is selected when determining primary key

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Use the default shard when resetting primary key
+
 ## v5.4.1
 
 ### Fixed

--- a/lib/active_record_shards/connection_switcher.rb
+++ b/lib/active_record_shards/connection_switcher.rb
@@ -24,6 +24,9 @@ module ActiveRecordShards
 
       base.singleton_class.send(:alias_method, :table_exists_without_default_shard?, :table_exists?)
       base.singleton_class.send(:alias_method, :table_exists?, :table_exists_with_default_shard?)
+
+      base.singleton_class.send(:alias_method, :reset_primary_key_without_default_shard, :reset_primary_key)
+      base.singleton_class.send(:alias_method, :reset_primary_key, :reset_primary_key_with_default_shard)
     end
 
     def on_primary_db(&block)
@@ -148,6 +151,10 @@ module ActiveRecordShards
 
     def shard_names
       config_for_env[SHARD_NAMES_CONFIG_KEY] || []
+    end
+
+    def reset_primary_key_with_default_shard
+      with_default_shard { reset_primary_key_without_default_shard }
     end
 
     private

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -208,6 +208,12 @@ describe "connection switching" do
         assert_equal 1, res.size
       end
     end
+
+    describe "when loading primary keys" do
+      it "uses the default shard" do
+        refute_nil Ticket.primary_key
+      end
+    end
   end
 
   describe "fibers" do


### PR DESCRIPTION
When the primary key is determined for a model, [this query](https://github.com/rails/rails/blob/7d949d7c81d2ec3c6d21525ebb08c85f3f174b74/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L495-L502) returns `nil` if the table in question is not found. This value gets cached for the model, as well as in the schema cache. While calling `reset_primary_key` will [reset the cached value](https://github.com/rails/rails/blob/7d949d7c81d2ec3c6d21525ebb08c85f3f174b74/activerecord/lib/active_record/attribute_methods/primary_key.rb#L81-L86) for the model, it [doesn't reset the cached value](https://github.com/rails/rails/blob/7d949d7c81d2ec3c6d21525ebb08c85f3f174b74/activerecord/lib/active_record/connection_adapters/schema_cache.rb#L79-L85) in the schema cache, and the primary key may remain `nil`.

To ensure the primary key is found, use the default shard when reseting primary key, the same way we do when [loading the schema](https://github.com/zendesk/active_record_shards/blob/cf862764cefd00f392ab5b9ebc577687839a3635/lib/active_record_shards/connection_switcher.rb#L245-L247) or checking if a [table exists](https://github.com/zendesk/active_record_shards/blob/cf862764cefd00f392ab5b9ebc577687839a3635/lib/active_record_shards/connection_switcher.rb#L249-L251).

I can currently replicate this problem in a classic development environment with eager loading enabled. The load order consistently results in a primary key being nil because the correct shard is not selected.