### PR TITLE
Fix SqlComments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v5.5.1
 ### Fixed
 * Fixed `SqlComments` when using Rails 7.0.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed `SqlComments` when using Rails 7.0.
+
 ## v5.5.0
 
 ### Changed

--- a/active_record_shards.gemspec
+++ b/active_record_shards.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new "active_record_shards", "5.5.0" do |s|
+Gem::Specification.new "active_record_shards", "5.5.1" do |s|
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Mick Staugaard", "Eric Chapweske", "Ben Osheroff"]
   s.email       = ["bquorning@zendesk.com", "gabe@zendesk.com", "pschambacher@zendesk.com", "mick@staugaard.com"]
   s.homepage    = "https://github.com/zendesk/active_record_shards"

--- a/lib/active_record_shards/sql_comments.rb
+++ b/lib/active_record_shards/sql_comments.rb
@@ -2,13 +2,13 @@
 module ActiveRecordShards
   module SqlComments
     module Methods
-      def execute(query, name = nil)
+      def execute(query, name = nil, **kwargs)
         shard = ActiveRecord::Base.current_shard_selection.shard
         shard_text = shard ? "shard #{shard}" : 'unsharded'
         replica = ActiveRecord::Base.current_shard_selection.on_replica?
         replica_text = replica ? 'replica' : 'primary'
         query = "/* #{shard_text} #{replica_text} */ " + query
-        super(query, name)
+        super(query, name, **kwargs)
       end
     end
 

--- a/test/active_record_shards/sql_comments_test.rb
+++ b/test/active_record_shards/sql_comments_test.rb
@@ -2,23 +2,32 @@
 
 require_relative '../helper'
 require 'active_record_shards/sql_comments'
+require 'active_record/connection_adapters/mysql2_adapter'
 
 describe ActiveRecordShards::SqlComments do
   with_fresh_databases
 
-  class CommentTester
-    attr_reader :called
+  class CustomAdapter < ActiveRecord::ConnectionAdapters::Mysql2Adapter
     prepend ActiveRecordShards::SqlComments::Methods
-
-    def execute(query, _name = nil)
-      (@called ||= []) << query
-    end
   end
 
-  let(:comment) { CommentTester.new }
+  before do
+    ActiveRecord::Base.establish_connection(RAILS_ENV.to_sym)
+  end
 
   it "adds sql comment" do
-    comment.execute("foo")
-    assert_equal ["/* unsharded primary */ foo"], comment.called
+    old_logger = ActiveRecord::Base.logger
+    new_logger = StringIO.new
+    ActiveRecord::Base.logger = Logger.new(new_logger)
+    config = Account.connection.instance_variable_get(:@config)
+    custom_connection = CustomAdapter.new(Mysql2::Client.new(config), nil, nil, config)
+
+    Account.stub :connection, custom_connection do
+      Account.first
+    end
+
+    assert_includes(new_logger.string, "/* unsharded primary */")
+  ensure
+    ActiveRecord::Base.logger = old_logger
   end
 end

--- a/test/connection_switching_test.rb
+++ b/test/connection_switching_test.rb
@@ -14,7 +14,6 @@ describe "connection switching" do
 
   before do
     ActiveRecord::Base.establish_connection(RAILS_ENV.to_sym)
-    require 'models'
   end
 
   describe "legacy_connection_handling" do

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -37,6 +37,7 @@ end
 BaseMigration = ActiveRecord::Migration[4.2]
 
 require 'active_support/test_case'
+require 'models'
 
 # support multiple before/after blocks per example
 module SpecDslPatch


### PR DESCRIPTION
`SqlComments` is broken in Rails 7.0 because it now passes an `async` kwarg[^1] when it used to only have the two positional arguments.

[^1]:(https://github.com/rails/rails/blob/5873d6279a2b2ec11d0176da66df17b076733791/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L194)

I've updated the tests to... actually test with Rails. Before it didn't run any Rails code at all.

Releases the patch as `v5.5.1`.